### PR TITLE
Table exporter basic CREATE TABLE DROP TABLE

### DIFF
--- a/src/main/java/com/google/cloud/spanner/hibernate/SpannerTableExporter.java
+++ b/src/main/java/com/google/cloud/spanner/hibernate/SpannerTableExporter.java
@@ -21,6 +21,7 @@ package com.google.cloud.spanner.hibernate;
 import java.text.MessageFormat;
 import java.util.Iterator;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 import org.hibernate.boot.Metadata;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Table;
@@ -52,9 +53,10 @@ public class SpannerTableExporter implements Exporter<Table> {
     String createTableTemplate = this.spannerDialect.getCreateTableString()
         + " {0} ({1}) PRIMARY KEY ({2})";
 
-    StringJoiner primaryKeyColNames = new StringJoiner(",");
-
-    table.getPrimaryKey().getColumns().forEach(col -> primaryKeyColNames.add(col.getName()));
+    String primaryKeyColNames = table.getPrimaryKey().getColumns()
+        .stream()
+        .map(Column::getName)
+        .collect(Collectors.joining(","));
 
     StringJoiner colsAndTypes = new StringJoiner(",");
 
@@ -64,7 +66,7 @@ public class SpannerTableExporter implements Exporter<Table> {
 
     return new String[]{
         MessageFormat.format(createTableTemplate, table.getName(), colsAndTypes.toString(),
-            primaryKeyColNames.toString())};
+            primaryKeyColNames)};
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/hibernate/SpannerTableExporter.java
+++ b/src/main/java/com/google/cloud/spanner/hibernate/SpannerTableExporter.java
@@ -18,7 +18,11 @@
 
 package com.google.cloud.spanner.hibernate;
 
+import java.text.MessageFormat;
+import java.util.Iterator;
+import java.util.StringJoiner;
 import org.hibernate.boot.Metadata;
+import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.schema.spi.Exporter;
 
@@ -41,17 +45,36 @@ public class SpannerTableExporter implements Exporter<Table> {
   }
 
   @Override
-  public String[] getSqlCreateStrings(Table exportable, Metadata metadata) {
-    return new String[]{"test_placeholder"};
+  public String[] getSqlCreateStrings(Table table, Metadata metadata) {
+    /* The current implementation does not support interleaved tables for collections
+     * or UNIQUE constraints/indexes for relationships
+     * */
+    String createTableTemplate = this.spannerDialect.getCreateTableString()
+        + " {0} ({1}) PRIMARY KEY ({2})";
+
+    StringJoiner primaryKeyColNames = new StringJoiner(",");
+
+    table.getPrimaryKey().getColumns().forEach(col -> primaryKeyColNames.add(col.getName()));
+
+    StringJoiner colsAndTypes = new StringJoiner(",");
+
+    ((Iterator<Column>) table.getColumnIterator()).forEachRemaining(col -> colsAndTypes
+        .add(col.getName() + " " + col.getSqlType(this.spannerDialect, metadata) + (col.isNullable()
+            ? this.spannerDialect.getNullColumnString() : " not null")));
+
+    return new String[]{
+        MessageFormat.format(createTableTemplate, table.getName(), colsAndTypes.toString(),
+            primaryKeyColNames.toString())};
   }
 
   @Override
   public String[] getSqlDropStrings(Table table, Metadata metadata) {
-    /*
-     * Cloud Spanner requires examining the metadata to find all indexes and interleaved tables.
+    /* Cloud Spanner requires examining the metadata to find all indexes and interleaved tables.
      * These must be dropped before the given table can be dropped.
-     */
+     *
+     * The current implementation does not support indexes or interleaved tables and indexes.
+     * */
 
-    return new String[]{"test_placeholder"};
+    return new String[]{this.spannerDialect.getDropTableString(table.getName())};
   }
 }

--- a/src/test/java/com/google/cloud/spanner/hibernate/SpannerDialectTest.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/SpannerDialectTest.java
@@ -212,4 +212,9 @@ public class SpannerDialectTest {
   public void getDropStringTest() {
     assertEquals("drop table test_table", this.spannerDialect.getDropTableString("test_table"));
   }
+
+  @Test
+  public void getCreateTableStringTest() {
+    assertEquals("create table", this.spannerDialect.getCreateTableString());
+  }
 }

--- a/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
@@ -71,12 +71,9 @@ public class SpannerTableExporterTests {
     new SchemaExport().setOutputFile(testFileName)
         .drop(EnumSet.of(TargetType.STDOUT, TargetType.SCRIPT), this.metadata);
     File scriptFile = new File(testFileName);
+    scriptFile.deleteOnExit();
     List<String> statements = Files.readAllLines(scriptFile.toPath());
-    try {
-      assertEquals("drop table test_table", statements.get(0));
-    } finally {
-      scriptFile.delete();
-    }
+    assertEquals("drop table test_table", statements.get(0));
   }
 
   @Test
@@ -85,20 +82,17 @@ public class SpannerTableExporterTests {
     new SchemaExport().setOutputFile(testFileName)
         .createOnly(EnumSet.of(TargetType.STDOUT, TargetType.SCRIPT), this.metadata);
     File scriptFile = new File(testFileName);
+    scriptFile.deleteOnExit();
     List<String> statements = Files.readAllLines(scriptFile.toPath());
-    try {
-      // The types in the following string need to be updated when SpannerDialect
-      // implementation maps types.
-      assertEquals("create table test_table "
-          + "(id1 bigint not null,"
-          + "id2 varchar(255) not null,"
-          + "boolVal boolean not null,"
-          + "longVal bigint not null,"
-          + "stringVal varchar(255)"
-          + ") PRIMARY KEY (id1,id2)", statements.get(0));
-    } finally {
-      scriptFile.delete();
-    }
+    // The types in the following string need to be updated when SpannerDialect
+    // implementation maps types.
+    assertEquals("create table test_table "
+        + "(id1 bigint not null,"
+        + "id2 varchar(255) not null,"
+        + "boolVal boolean not null,"
+        + "longVal bigint not null,"
+        + "stringVal varchar(255)"
+        + ") PRIMARY KEY (id1,id2)", statements.get(0));
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
@@ -27,6 +27,8 @@ import java.nio.file.Files;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
+import javax.persistence.Entity;
+import org.hibernate.AnnotationException;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
@@ -34,7 +36,9 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.schema.TargetType;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  * Tests for SpannerTableExporter.
@@ -42,6 +46,9 @@ import org.junit.Test;
  * @author Chengyuan Zhao
  */
 public class SpannerTableExporterTests {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   private Metadata metadata;
 
@@ -66,7 +73,7 @@ public class SpannerTableExporterTests {
     File scriptFile = new File(testFileName);
     List<String> statements = Files.readAllLines(scriptFile.toPath());
     try {
-      assertEquals("test_placeholder", statements.get(0));
+      assertEquals("drop table test_table", statements.get(0));
     } finally {
       scriptFile.delete();
     }
@@ -76,13 +83,52 @@ public class SpannerTableExporterTests {
   public void generateCreateStringsTest() throws IOException {
     String testFileName = UUID.randomUUID().toString();
     new SchemaExport().setOutputFile(testFileName)
-        .create(EnumSet.of(TargetType.STDOUT, TargetType.SCRIPT), this.metadata);
+        .createOnly(EnumSet.of(TargetType.STDOUT, TargetType.SCRIPT), this.metadata);
     File scriptFile = new File(testFileName);
     List<String> statements = Files.readAllLines(scriptFile.toPath());
     try {
-      assertEquals("test_placeholder", statements.get(0));
+      // The types in the following string need to be updated when SpannerDialect
+      // implementation maps types.
+      assertEquals("create table test_table "
+          + "(id1 bigint not null,"
+          + "id2 varchar(255) not null,"
+          + "boolVal boolean not null,"
+          + "longVal bigint not null,"
+          + "stringVal varchar(255)"
+          + ") PRIMARY KEY (id1,id2)", statements.get(0));
     } finally {
       scriptFile.delete();
     }
+  }
+
+  @Test
+  public void generateCreateStringsEmptyEntityTest() {
+    this.expectedException.expect(AnnotationException.class);
+    this.expectedException.expectMessage("No identifier specified for entity:");
+    new SchemaExport().setOutputFile("unused")
+        .createOnly(EnumSet.of(TargetType.STDOUT, TargetType.SCRIPT),
+            new MetadataSources(this.registry).addAnnotatedClass(EmptyEntity.class)
+                .buildMetadata());
+  }
+
+  @Test
+  public void generateCreateStringsNoPkEntityTest() {
+    this.expectedException.expect(AnnotationException.class);
+    this.expectedException.expectMessage("No identifier specified for entity:");
+    new SchemaExport().setOutputFile("unused")
+        .createOnly(EnumSet.of(TargetType.STDOUT, TargetType.SCRIPT),
+            new MetadataSources(this.registry).addAnnotatedClass(NoPkEntity.class).buildMetadata());
+  }
+
+  @Entity
+  class EmptyEntity {
+    // Intentionally empty
+  }
+
+  @Entity
+  class NoPkEntity {
+
+    // Intentionally no primary key annotated
+    String value;
   }
 }

--- a/src/test/java/com/google/cloud/spanner/hibernate/util/TestEntity.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/util/TestEntity.java
@@ -18,8 +18,12 @@
 
 package com.google.cloud.spanner.hibernate.util;
 
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.Id;
+import javax.persistence.Table;
 
 /**
  * A test entity class used for generating schema statements.
@@ -27,8 +31,23 @@ import javax.persistence.Id;
  * @author Chengyuan Zhao
  */
 @Entity
+@Table(name = "test_table")
 public class TestEntity {
 
-  @Id
-  String id;
+  @EmbeddedId
+  IdClass id;
+
+  @Column(nullable = true)
+  String stringVal;
+
+  boolean boolVal;
+
+  long longVal;
+
+  @Embeddable
+  public class IdClass implements Serializable {
+
+    long id1;
+    String id2;
+  }
 }


### PR DESCRIPTION
fixes #3 
basic support for CREATE TABLE and DROP TABLE for simple use cases at alpha-level.

#17 will address the issue of creating and dropping tables when there are interleaved indexes or child-tables as needed for advanced features.