### PR TITLE
Write script to run integration testing the Hibernate Dialect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ target
 
 # Ignores generated files through testing
 testing/hibernate-orm
-testing/hibernate-orm/**
 testing/.gradle

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ target
 # intellij / idea
 *.iml
 .idea
+
+# Ignores generated files through testing
+testing/hibernate-orm
+testing/hibernate-orm/**
+testing/.gradle

--- a/testing/README.md
+++ b/testing/README.md
@@ -3,6 +3,9 @@
 This directory contains a script which allows you to run the Spanner-Hibernate dialect against
 the integration tests provided in the [Hibernate ORM repository](https://github.com/hibernate/hibernate-orm).
 
+The script will take your local working copy of `google-cloud-spanner-hibernate` and install to
+local maven in order to facilitate testing, so it will allow you to test local changes.
+
 ## Instructions
 
 1. Install Python3 on your machine.

--- a/testing/README.md
+++ b/testing/README.md
@@ -28,7 +28,9 @@ You will need to specify the correct GCP project ID, Spanner instance, and table
     ```
 
 3. Run `python3 run-tests.py`. Note that the script will run all the integration tests in the
-directory. It is likely you may want to run a specific test for debugging; this can be done
-by modifying the script and filtering the tests using `--tests` in the Gradle command.
-
-    Example: `hibernate-orm/gradlew test -p hibernate-orm/documentation --tests <TEST_NAME>`
+directory. It is likely you may want to run a specific test for debugging; this can be done passing in a tests filter as a commandline argument to the script:
+    
+    Example:
+    ```
+    python3 run-tests.py SQLTest.test_sql_jpa_all_columns_scalar_query_example
+    ```

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,31 @@
+# Spanner-Hibernate Integration Testing
+
+This directory contains a script which allows you to run the Spanner-Hibernate dialect against
+the integration tests provided in the [Hibernate ORM repository](https://github.com/hibernate/hibernate-orm).
+
+## Instructions
+
+1. Install Python3 on your machine.
+
+    Verify you have it installed by running:
+    
+    ```SHELL
+    $ python3 --version
+   
+    Python 3.5.4rc1 
+    ```
+
+2. Modify `databases.gradle` to include the correct JDBC URL to connect to your Spanner instance.
+You will need to specify the correct GCP project ID, Spanner instance, and table.
+
+    Example: 
+    
+    ```
+    'jdbc.url' : 'jdbc:cloudspanner://;Project=gcp_project_id;Instance=spanner_instance_name;Database=my_db'
+    ```
+
+3. Run `python3 run-tests.py`. Note that the script will run all the integration tests in the
+directory. It is likely you may want to run a specific test for debugging; this can be done
+by modifying the script and filtering the tests using `--tests` in the Gradle command.
+
+    Example: `hibernate-orm/gradlew test -p hibernate-orm/documentation --tests <TEST_NAME>`

--- a/testing/databases.gradle
+++ b/testing/databases.gradle
@@ -1,10 +1,3 @@
-/*
- * Hibernate, Relational Persistence for Idiomatic Java
- *
- * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
- * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
- */
-
 // Note: The JDBC URL must be configured properly to your GCP Project settings.
 ext {
         db = 'spanner'

--- a/testing/databases.gradle
+++ b/testing/databases.gradle
@@ -1,0 +1,20 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+// Note: The JDBC URL must be configured properly to your GCP Project settings.
+ext {
+        db = 'spanner'
+        dbBundle = [
+                spanner : [
+                        'db.dialect' : 'com.google.cloud.spanner.hibernate.SpannerDialect',
+                        'jdbc.driver' : 'com.simba.cloudspanner.core.jdbc42.CloudSpanner42Driver',
+                        'jdbc.user' : '',
+                        'jdbc.pass' : '',
+                        'jdbc.url' : 'jdbc:cloudspanner://;Project=PROJECT_NAME;Instance=SPANNER_INSTANCE_NAME;Database=DATABASE_NAME',
+                ],
+        ]
+}

--- a/testing/documentation.gradle
+++ b/testing/documentation.gradle
@@ -1,0 +1,41 @@
+apply from: rootProject.file( 'gradle/java-module.gradle' )
+
+apply plugin: 'hibernate-matrix-testing'
+
+repositories {
+    mavenLocal()
+}
+
+dependencies {
+    ext.pressgangVersion = '3.0.0'
+
+    // Spanner-Hibernate testing deps
+    compile files("$rootProject.projectDir/libs/CloudSpannerJDBC42.jar")
+    testCompile "com.google.cloud:google-cloud-spanner-hibernate:0.1.0-SNAPSHOT"
+
+    compile( libraries.jpa )
+    compile( project( ':hibernate-core' ) )
+    annotationProcessor( project( ':hibernate-jpamodelgen' ) )
+
+    testCompile( 'org.apache.commons:commons-lang3:3.4' )
+
+    testCompile( project(':hibernate-envers') )
+    testCompile( project(':hibernate-spatial') )
+    testCompile( project(path: ':hibernate-core', configuration: 'tests') )
+
+    testCompile( project(':hibernate-testing') )
+
+    testCompile "org.osgi:org.osgi.core:4.3.1"
+
+    testCompile( libraries.mockito )
+    testCompile( libraries.mockito_inline )
+
+    testCompile( project( ':hibernate-jcache' ) )
+    testRuntime( libraries.ehcache3 )
+}
+
+// Not used; needed because this task is referenced in other gradle files.
+task buildDocsForPublishing {
+    group 'Documentation'
+    description 'Grouping task for building all documentation for publishing (release)'
+}

--- a/testing/run-tests.py
+++ b/testing/run-tests.py
@@ -19,8 +19,7 @@ else:
   subprocess.run(['git', 'clone', HIBERNATE_TESTS_REPO])
 
 # Copy the JDBC driver to directory if it does not already exist.
-libs = [file for file in os.listdir('hibernate-orm/libs')]
-if 'CloudSpannerJDBC42.jar' not in libs:
+if 'CloudSpannerJDBC42.jar' not in os.listdir('hibernate-orm/libs'):
   print('Downloading Spanner JDBC driver')
   subprocess.run('gsutil cp gs://spanner-jdbc-bucket/CloudSpannerJDBC42.jar hibernate-orm/libs/', shell=True)
 

--- a/testing/run-tests.py
+++ b/testing/run-tests.py
@@ -12,11 +12,17 @@ HIBERNATE_TESTS_REPO = 'https://github.com/dzou/hibernate-orm.git'
 subprocess.run('mvn install -DskipTests -f ../pom.xml', shell=True)
 
 # Clone the Hibernate Tests repository if not present.
-subdirectories = [folder for folder in os.listdir(".") if os.path.isdir(folder)]
+subdirectories = [folder for folder in os.listdir('.') if os.path.isdir(folder)]
 if 'hibernate-orm' in subdirectories:
   print('The hibernate-orm directory already exists; will omit cloning step.')
 else:
   subprocess.run(['git', 'clone', HIBERNATE_TESTS_REPO])
+
+# Copy the JDBC driver to directory if it does not already exist.
+libs = [file for file in os.listdir('hibernate-orm/libs')]
+if 'CloudSpannerJDBC42.jar' not in libs:
+  print('Downloading Spanner JDBC driver')
+  subprocess.run('gsutil cp gs://spanner-jdbc-bucket/CloudSpannerJDBC42.jar hibernate-orm/libs/', shell=True)
 
 # Update the databases.gradle file with the current version.
 subprocess.run('cp databases.gradle hibernate-orm/gradle/databases.gradle', shell=True)

--- a/testing/run-tests.py
+++ b/testing/run-tests.py
@@ -6,7 +6,7 @@ Script for running Hibernate Integration tests against the
 Spanner-Hibernate dialect.
 '''
 
-HIBERNATE_TESTS_REPO = 'https://github.com/dzou/hibernate-orm.git'
+HIBERNATE_TESTS_REPO = 'https://github.com/hibernate/hibernate-orm.git'
 
 # Install
 subprocess.run('mvn install -DskipTests -f ../pom.xml', shell=True)
@@ -19,13 +19,15 @@ else:
   subprocess.run(['git', 'clone', HIBERNATE_TESTS_REPO])
 
 # Copy the JDBC driver to directory if it does not already exist.
-if 'CloudSpannerJDBC42.jar' not in os.listdir('hibernate-orm/libs'):
+if not os.path.isdir('hibernate-orm/libs') or \
+    'CloudSpannerJDBC42.jar' not in os.listdir('hibernate-orm/libs'):
   print('Downloading Spanner JDBC driver')
-  subprocess.run('gsutil cp gs://spanner-jdbc-bucket/CloudSpannerJDBC42.jar hibernate-orm/libs/', shell=True)
+  subprocess.run('gsutil cp gs://spanner-jdbc-bucket/CloudSpannerJDBC42.jar hibernate-orm/libs/CloudSpannerJDBC42.jar', shell=True)
 
-# Update the databases.gradle file with the current version.
+# Patch the hibernate-orm repo with custom Gradle files for testing
 subprocess.run('cp databases.gradle hibernate-orm/gradle/databases.gradle', shell=True)
+subprocess.run('cp documentation.gradle hibernate-orm/documentation/documentation.gradle', shell=True)
 
 # Run some tests.
 # Modify this to filter down to a specific test with --test TEST_NAME
-subprocess.run('hibernate-orm/gradlew test -p hibernate-orm/documentation', shell=True)
+subprocess.run('hibernate-orm/gradlew test -p hibernate-orm/documentation -Pdb=spanner --tests TuplizerTest', shell=True)

--- a/testing/run-tests.py
+++ b/testing/run-tests.py
@@ -1,0 +1,26 @@
+import os
+import subprocess
+
+'''
+Script for running Hibernate Integration tests against the
+Spanner-Hibernate dialect.
+'''
+
+HIBERNATE_TESTS_REPO = 'https://github.com/dzou/hibernate-orm.git'
+
+# Install
+subprocess.run('mvn install -DskipTests -f ../pom.xml', shell=True)
+
+# Clone the Hibernate Tests repository if not present.
+subdirectories = [folder for folder in os.listdir(".") if os.path.isdir(folder)]
+if 'hibernate-orm' in subdirectories:
+  print('The hibernate-orm directory already exists; will omit cloning step.')
+else:
+  subprocess.run(['git', 'clone', HIBERNATE_TESTS_REPO])
+
+# Update the databases.gradle file with the current version.
+subprocess.run('cp databases.gradle hibernate-orm/gradle/databases.gradle', shell=True)
+
+# Run some tests.
+# Modify this to filter down to a specific test with --test TEST_NAME
+subprocess.run('hibernate-orm/gradlew test -p hibernate-orm/documentation', shell=True)

--- a/testing/run-tests.py
+++ b/testing/run-tests.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 '''
 Script for running Hibernate Integration tests against the
@@ -30,6 +31,10 @@ subprocess.run('cp databases.gradle hibernate-orm/gradle/databases.gradle', shel
 subprocess.run('cp documentation.gradle hibernate-orm/documentation/documentation.gradle', shell=True)
 
 # Run some tests.
-# Modify this to filter down to a different test with --tests TEST_NAME
-subprocess.run('hibernate-orm/gradlew clean test -p hibernate-orm/documentation --tests SQLTest', shell=True)
+# Use commandline args to specify which tests to run: python3 run-tests.py [TEST_NAME]
+if len(sys.argv) == 1:
+  tests = 'SQLTest' # all tests
+else:
+  tests = sys.argv[1] # example: SQLTest.test_sql_jpa_all_columns_scalar_query_example
+subprocess.run('hibernate-orm/gradlew clean test -p hibernate-orm/documentation --tests ' + tests, shell=True)
 subprocess.run('google-chrome hibernate-orm/documentation/target/reports/tests/test/index.html', shell=True)

--- a/testing/run-tests.py
+++ b/testing/run-tests.py
@@ -15,6 +15,7 @@ subprocess.run('mvn install -DskipTests -f ../pom.xml', shell=True)
 subdirectories = [folder for folder in os.listdir('.') if os.path.isdir(folder)]
 if 'hibernate-orm' in subdirectories:
   print('The hibernate-orm directory already exists; will omit cloning step.')
+  subprocess.run('git -C hibernate-orm pull', shell=True)
 else:
   subprocess.run(['git', 'clone', HIBERNATE_TESTS_REPO])
 
@@ -29,5 +30,6 @@ subprocess.run('cp databases.gradle hibernate-orm/gradle/databases.gradle', shel
 subprocess.run('cp documentation.gradle hibernate-orm/documentation/documentation.gradle', shell=True)
 
 # Run some tests.
-# Modify this to filter down to a specific test with --tests TEST_NAME
-subprocess.run('hibernate-orm/gradlew clean test -p hibernate-orm/documentation -Pdb=spanner --tests SQLTest', shell=True)
+# Modify this to filter down to a different test with --tests TEST_NAME
+subprocess.run('hibernate-orm/gradlew clean test -p hibernate-orm/documentation --tests SQLTest', shell=True)
+subprocess.run('google-chrome hibernate-orm/documentation/target/reports/tests/test/index.html', shell=True)

--- a/testing/run-tests.py
+++ b/testing/run-tests.py
@@ -29,5 +29,5 @@ subprocess.run('cp databases.gradle hibernate-orm/gradle/databases.gradle', shel
 subprocess.run('cp documentation.gradle hibernate-orm/documentation/documentation.gradle', shell=True)
 
 # Run some tests.
-# Modify this to filter down to a specific test with --test TEST_NAME
-subprocess.run('hibernate-orm/gradlew test -p hibernate-orm/documentation -Pdb=spanner --tests TuplizerTest', shell=True)
+# Modify this to filter down to a specific test with --tests TEST_NAME
+subprocess.run('hibernate-orm/gradlew clean test -p hibernate-orm/documentation -Pdb=spanner --tests SQLTest', shell=True)


### PR DESCRIPTION
This adds a script which allows you to run Hibernate integration tests against our Spanner Dialect locally.

This will clone (my fork) of the hibernate-orm repo, install the current version of Spanner Dialect to Maven local repo, and then run the hibernate tests.

Contributes to #4.