### PR TITLE
Add no-op exporters for the Dialect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,12 @@
       <version>1.2.17</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.11.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/google/cloud/spanner/hibernate/SpannerDialect.java
+++ b/src/main/java/com/google/cloud/spanner/hibernate/SpannerDialect.java
@@ -50,9 +50,7 @@ public class SpannerDialect extends Dialect {
 
   private static final LockingStrategy LOCKING_STRATEGY = new DoNothingLockingStrategy();
 
-  private static final Exporter<Sequence> NOOP_SEQUENCE_EXPORTER = new EmptyExporter<>();
-  private static final Exporter<ForeignKey> NOOP_FK_EXPORTER = new EmptyExporter<>();
-  private static final Exporter<Constraint> NOOP_CONSTRAINT_EXPORTER = new EmptyExporter<>();
+  private static final Exporter NOOP_EXPORTER = new EmptyExporter();
 
   @Override
   public Exporter<Table> getTableExporter() {
@@ -259,17 +257,17 @@ public class SpannerDialect extends Dialect {
 
   @Override
   public Exporter<Sequence> getSequenceExporter() {
-    return NOOP_SEQUENCE_EXPORTER;
+    return NOOP_EXPORTER;
   }
 
   @Override
   public Exporter<ForeignKey> getForeignKeyExporter() {
-    return NOOP_FK_EXPORTER;
+    return NOOP_EXPORTER;
   }
 
   @Override
   public Exporter<Constraint> getUniqueKeyExporter() {
-    return NOOP_CONSTRAINT_EXPORTER;
+    return NOOP_EXPORTER;
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/hibernate/SpannerDialect.java
+++ b/src/main/java/com/google/cloud/spanner/hibernate/SpannerDialect.java
@@ -24,7 +24,6 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.boot.Metadata;
-import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
 import org.hibernate.boot.model.relational.Sequence;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.lock.LockingStrategy;

--- a/src/main/java/com/google/cloud/spanner/hibernate/SpannerDialect.java
+++ b/src/main/java/com/google/cloud/spanner/hibernate/SpannerDialect.java
@@ -23,11 +23,16 @@ import java.util.Map;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.StaleObjectStateException;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
+import org.hibernate.boot.model.relational.Sequence;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.lock.LockingStrategy;
 import org.hibernate.dialect.lock.LockingStrategyException;
 import org.hibernate.engine.jdbc.env.spi.SchemaNameResolver;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.mapping.Constraint;
+import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.persister.entity.Lockable;
 import org.hibernate.tool.schema.spi.Exporter;
@@ -37,6 +42,7 @@ import org.hibernate.tool.schema.spi.Exporter;
  *
  * @author Mike Eltsufin
  * @author Chengyuan Zhao
+ * @author Daniel Zou
  */
 public class SpannerDialect extends Dialect {
 
@@ -243,6 +249,53 @@ public class SpannerDialect extends Dialect {
   public String getForUpdateSkipLockedString(String aliases) {
     throw new UnsupportedOperationException("Cloud Spanner does not support selecting for lock"
         + " acquisition.");
+  }
+
+  /* Unsupported Hibernate Exporters */
+
+  @Override
+  public Exporter<Sequence> getSequenceExporter() {
+    return new Exporter<Sequence>() {
+      @Override
+      public String[] getSqlCreateStrings(Sequence exportable, Metadata metadata) {
+        return new String[0];
+      }
+
+      @Override
+      public String[] getSqlDropStrings(Sequence exportable, Metadata metadata) {
+        return new String[0];
+      }
+    };
+  }
+
+  @Override
+  public Exporter<ForeignKey> getForeignKeyExporter() {
+    return new Exporter<ForeignKey>() {
+      @Override
+      public String[] getSqlCreateStrings(ForeignKey exportable, Metadata metadata) {
+        return new String[0];
+      }
+
+      @Override
+      public String[] getSqlDropStrings(ForeignKey exportable, Metadata metadata) {
+        return new String[0];
+      }
+    };
+  }
+
+  @Override
+  public Exporter<Constraint> getUniqueKeyExporter() {
+    return new Exporter<Constraint>() {
+      @Override
+      public String[] getSqlCreateStrings(Constraint exportable, Metadata metadata) {
+        return new String[0];
+      }
+
+      @Override
+      public String[] getSqlDropStrings(Constraint exportable, Metadata metadata) {
+        return new String[0];
+      }
+    };
   }
 
   @Override

--- a/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
@@ -1,0 +1,67 @@
+package com.google.cloud.spanner.hibernate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.cloud.spanner.hibernate.entities.Employee;
+import com.mockrunner.mock.jdbc.JDBCMockObjectFactory;
+import java.util.List;
+import org.hibernate.Session;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GeneratedCreateTableStatementsTests {
+
+  private Metadata metadata;
+
+  private StandardServiceRegistry registry;
+
+  private JDBCMockObjectFactory jdbcMockObjectFactory;
+
+  /**
+   * Set up the metadata for Hibernate to generate schema statements.
+   */
+  @Before
+  public void setup() {
+    this.jdbcMockObjectFactory = new JDBCMockObjectFactory();
+    this.jdbcMockObjectFactory.registerMockDriver();
+    this.jdbcMockObjectFactory.getMockDriver()
+        .setupConnection(this.jdbcMockObjectFactory.getMockConnection());
+
+    this.registry = new StandardServiceRegistryBuilder()
+        .applySetting("hibernate.dialect", SpannerDialect.class.getName())
+        // must NOT set a driver class name so that Hibernate will use java.sql.DriverManager
+        // and discover the only mock driver we have set up.
+        .applySetting("hibernate.connection.url", "unused")
+        .applySetting("hibernate.connection.username", "unused")
+        .applySetting("hibernate.connection.password", "unused")
+        .applySetting("hibernate.hbm2ddl.auto", "create")
+        .build();
+
+    this.metadata =
+        new MetadataSources(this.registry)
+            .addAnnotatedClass(Employee.class)
+            .buildMetadata();
+  }
+
+
+  @Test
+  public void testUnsupportedExportersNoop() {
+    Session session = this.metadata.buildSessionFactory().openSession();
+    session.beginTransaction();
+    session.close();
+
+    List<String> sqlStrings = this.jdbcMockObjectFactory.getMockConnection()
+        .getStatementResultSetHandler()
+        .getExecutedStatements();
+
+    assertThat(sqlStrings).containsExactly(
+        "create table Employee (id bigint not null,name varchar(255),manager_id bigint) PRIMARY KEY (id)",
+        "drop table Employee");
+  }
+
+
+}

--- a/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
 package com.google.cloud.spanner.hibernate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,9 +77,8 @@ public class GeneratedCreateTableStatementsTests {
         .getExecutedStatements();
 
     assertThat(sqlStrings).containsExactly(
-        "create table Employee (id bigint not null,name varchar(255),manager_id bigint) PRIMARY KEY (id)",
+        "create table Employee "
+            + "(id bigint not null,name varchar(255),manager_id bigint) PRIMARY KEY (id)",
         "drop table Employee");
   }
-
-
 }

--- a/src/test/java/com/google/cloud/spanner/hibernate/GeneratedSelectStatementsTests.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/GeneratedSelectStatementsTests.java
@@ -20,9 +20,9 @@ package com.google.cloud.spanner.hibernate;
 
 import static org.junit.Assert.assertEquals;
 
-import com.google.cloud.spanner.hibernate.util.SubTestEntity;
-import com.google.cloud.spanner.hibernate.util.TestEntity;
-import com.google.cloud.spanner.hibernate.util.TestEntity.IdClass;
+import com.google.cloud.spanner.hibernate.entities.SubTestEntity;
+import com.google.cloud.spanner.hibernate.entities.TestEntity;
+import com.google.cloud.spanner.hibernate.entities.TestEntity.IdClass;
 import com.mockrunner.mock.jdbc.JDBCMockObjectFactory;
 import com.mockrunner.mock.jdbc.MockPreparedStatement;
 import java.util.List;

--- a/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
@@ -20,7 +20,7 @@ package com.google.cloud.spanner.hibernate;
 
 import static org.junit.Assert.assertEquals;
 
-import com.google.cloud.spanner.hibernate.util.TestEntity;
+import com.google.cloud.spanner.hibernate.entities.TestEntity;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/test/java/com/google/cloud/spanner/hibernate/entities/Employee.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/entities/Employee.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
 package com.google.cloud.spanner.hibernate.entities;
 
 import javax.persistence.CascadeType;

--- a/src/test/java/com/google/cloud/spanner/hibernate/entities/Employee.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/entities/Employee.java
@@ -1,0 +1,25 @@
+package com.google.cloud.spanner.hibernate.entities;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+/**
+ * A test entity that uses features in Hibernate that are unsupported in Spanner.
+ *
+ * @author Daniel Zou
+ */
+@Entity
+public class Employee {
+
+  @Id
+  public Long id;
+
+  @ManyToOne(cascade = {CascadeType.ALL})
+  public Employee manager;
+
+  @Column(unique = true)
+  public String name;
+}

--- a/src/test/java/com/google/cloud/spanner/hibernate/entities/SubTestEntity.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/entities/SubTestEntity.java
@@ -16,41 +16,26 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-package com.google.cloud.spanner.hibernate.util;
+package com.google.cloud.spanner.hibernate.entities;
 
-import java.io.Serializable;
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
-import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.Table;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinColumns;
+import javax.persistence.ManyToOne;
 
 /**
- * A test entity class used for generating schema statements.
+ * A test entity that has relationships with `TestEntity`.
  *
  * @author Chengyuan Zhao
  */
 @Entity
-@Table(name = "`test_table`")
-public class TestEntity {
+public class SubTestEntity {
 
-  @EmbeddedId
-  public IdClass id;
+  @Id
+  String id;
 
-  @Column(nullable = true)
-  public String stringVal;
-
-  @Column(name = "`boolColumn`")
-  public boolean boolVal;
-
-  public long longVal;
-
-  @Embeddable
-  public static class IdClass implements Serializable {
-
-    @Column(name = "`ID1`")
-    public long id1;
-
-    public String id2;
-  }
+  @ManyToOne
+  @JoinColumns({@JoinColumn(name = "id1"), @JoinColumn(name = "id2")})
+  TestEntity testEntity;
 }

--- a/src/test/java/com/google/cloud/spanner/hibernate/entities/TestEntity.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/entities/TestEntity.java
@@ -16,26 +16,41 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-package com.google.cloud.spanner.hibernate.util;
+package com.google.cloud.spanner.hibernate.entities;
 
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinColumns;
-import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 /**
- * A test entity that has relationships with `TestEntity`.
+ * A test entity class used for generating schema statements.
  *
  * @author Chengyuan Zhao
  */
 @Entity
-public class SubTestEntity {
+@Table(name = "`test_table`")
+public class TestEntity {
 
-  @Id
-  String id;
+  @EmbeddedId
+  public IdClass id;
 
-  @ManyToOne
-  @JoinColumns({@JoinColumn(name = "id1"), @JoinColumn(name = "id2")})
-  TestEntity testEntity;
+  @Column(nullable = true)
+  public String stringVal;
+
+  @Column(name = "`boolColumn`")
+  public boolean boolVal;
+
+  public long longVal;
+
+  @Embeddable
+  public static class IdClass implements Serializable {
+
+    @Column(name = "`ID1`")
+    public long id1;
+
+    public String id2;
+  }
 }


### PR DESCRIPTION
This adds Exporters which return empty string[] for unsupported features of the dialect.

Fixes #9.