### PR TITLE
Configure Dialect Testing to use Fork of hibernate-orm

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -18,19 +18,12 @@ local maven in order to facilitate testing, so it will allow you to test local c
     Python 3.5.4rc1 
     ```
 
-2. Modify `databases.gradle` to include the correct JDBC URL to connect to your Spanner instance.
-You will need to specify the correct GCP project ID, Spanner instance, and table.
-
-    Example: 
-    
-    ```
-    'jdbc.url' : 'jdbc:cloudspanner://;Project=gcp_project_id;Instance=spanner_instance_name;Database=my_db'
-    ```
-
-3. Run `python3 run-tests.py`. Note that the script will run all the integration tests in the
+2. Run `python3 run-tests.py`. Note that the script will run all the integration tests in the
 directory. It is likely you may want to run a specific test for debugging; this can be done passing in a tests filter as a commandline argument to the script:
     
     Example:
     ```
     python3 run-tests.py SQLTest.test_sql_jpa_all_columns_scalar_query_example
     ```
+
+See [our fork of hibernate-orm](https://github.com/dzou/hibernate-orm) which contains the modified tests.

--- a/testing/run-tests.py
+++ b/testing/run-tests.py
@@ -7,10 +7,10 @@ Script for running Hibernate Integration tests against the
 Spanner-Hibernate dialect.
 '''
 
-HIBERNATE_TESTS_REPO = 'https://github.com/hibernate/hibernate-orm.git'
+HIBERNATE_TESTS_REPO = 'https://github.com/dzou/hibernate-orm.git'
 
 # Install
-subprocess.run('mvn install -DskipTests -f ../pom.xml', shell=True)
+subprocess.run('mvn install -DskipTests -Dcheckstyle.skip -f ../pom.xml', shell=True)
 
 # Clone the Hibernate Tests repository if not present.
 subdirectories = [folder for folder in os.listdir('.') if os.path.isdir(folder)]
@@ -20,21 +20,12 @@ if 'hibernate-orm' in subdirectories:
 else:
   subprocess.run(['git', 'clone', HIBERNATE_TESTS_REPO])
 
-# Copy the JDBC driver to directory if it does not already exist.
-if not os.path.isdir('hibernate-orm/libs') or \
-    'CloudSpannerJDBC42.jar' not in os.listdir('hibernate-orm/libs'):
-  print('Downloading Spanner JDBC driver')
-  subprocess.run('gsutil cp gs://spanner-jdbc-bucket/CloudSpannerJDBC42.jar hibernate-orm/libs/CloudSpannerJDBC42.jar', shell=True)
-
-# Patch the hibernate-orm repo with custom Gradle files for testing
-subprocess.run('cp databases.gradle hibernate-orm/gradle/databases.gradle', shell=True)
-subprocess.run('cp documentation.gradle hibernate-orm/documentation/documentation.gradle', shell=True)
-
 # Run some tests.
 # Use commandline args to specify which tests to run: python3 run-tests.py [TEST_NAME]
 if len(sys.argv) == 1:
   tests = 'SQLTest' # all tests
 else:
   tests = sys.argv[1] # example: SQLTest.test_sql_jpa_all_columns_scalar_query_example
+
 subprocess.run('hibernate-orm/gradlew clean test -p hibernate-orm/documentation --tests ' + tests, shell=True)
 subprocess.run('google-chrome hibernate-orm/documentation/target/reports/tests/test/index.html', shell=True)


### PR DESCRIPTION
This configures the Dialect integration testing to use a local [fork of hibernate-orm](https://github.com/dzou/hibernate-orm), so we have the ability to make modifications to entities in the repo to get the tests to work. 