### PR TITLE
Fixes the tests and update pom.xml test naming

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,16 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*Tests.java</include>
+            <include>**/*Test.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.17</version>
         <configuration>

--- a/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
@@ -77,9 +77,10 @@ public class GeneratedCreateTableStatementsTests {
         .getExecutedStatements();
 
     assertThat(sqlStrings).containsExactly(
+        "drop index name_index",
         "drop table Employee",
         "create table Employee "
-            + "(id bigint not null,name varchar(255),manager_id bigint) PRIMARY KEY (id)",
+            + "(id INT64 not null,name STRING(255),manager_id INT64) PRIMARY KEY (id)",
         "create index name_index on Employee (name)");
   }
 }

--- a/src/test/java/com/google/cloud/spanner/hibernate/GeneratedSelectStatementsTests.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/GeneratedSelectStatementsTests.java
@@ -108,7 +108,8 @@ public class GeneratedSelectStatementsTests {
               .getPreparedStatementResultSetHandler().getPreparedStatements().stream()
               .map(MockPreparedStatement::getSQL).findFirst().get();
       assertThat(preparedStatement).isEqualTo(
-          "insert into `test_table` (`boolColumn`, longVal, stringVal, `ID1`, id2) values (?, ?, ?, ?, ?)");
+          "insert into `test_table` (`boolColumn`, longVal, "
+              + "stringVal, `ID1`, id2) values (?, ?, ?, ?, ?)");
     }
   }
 

--- a/src/test/java/com/google/cloud/spanner/hibernate/GeneratedSelectStatementsTests.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/GeneratedSelectStatementsTests.java
@@ -108,7 +108,7 @@ public class GeneratedSelectStatementsTests {
               .getPreparedStatementResultSetHandler().getPreparedStatements().stream()
               .map(MockPreparedStatement::getSQL).findFirst().get();
       assertThat(preparedStatement).isEqualTo(
-          "insert into test_table (boolVal, longVal, stringVal, id1, id2) values (?, ?, ?, ?, ?)");
+          "insert into `test_table` (`boolColumn`, longVal, stringVal, `ID1`, id2) values (?, ?, ?, ?, ?)");
     }
   }
 
@@ -116,7 +116,7 @@ public class GeneratedSelectStatementsTests {
   public void deleteDmlTest() {
     testUpdateStatementTranslation(
         "delete TestEntity where boolVal = true",
-        "delete from test_table where boolVal=TRUE");
+        "delete from `test_table` where `boolColumn`=TRUE");
   }
 
   @Test
@@ -124,8 +124,8 @@ public class GeneratedSelectStatementsTests {
     testReadStatementTranslation(
         "select s from SubTestEntity s inner join s.testEntity",
         "select subtestent0_.id as id1_0_, subtestent0_.id1 as id2_0_, "
-        + "subtestent0_.id2 as id3_0_ from SubTestEntity subtestent0_ inner join test_table "
-        + "testentity1_ on subtestent0_.id1=testentity1_.id1 "
+        + "subtestent0_.id2 as id3_0_ from SubTestEntity subtestent0_ inner join `test_table` "
+        + "testentity1_ on subtestent0_.id1=testentity1_.`ID1` "
             + "and subtestent0_.id2=testentity1_.id2");
   }
 

--- a/src/test/java/com/google/cloud/spanner/hibernate/SpannerDialectTests.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/SpannerDialectTests.java
@@ -32,7 +32,7 @@ import org.junit.Test;
  * @author Mike Eltsufin
  * @author Chengyuan Zhao
  */
-public class SpannerDialectTest {
+public class SpannerDialectTests {
 
   private SpannerDialect spannerDialect;
 

--- a/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
+++ b/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
@@ -101,8 +101,8 @@ public class SpannerTableExporterTests {
     // The types in the following string need to be updated when SpannerDialect
     // implementation maps types.
     String expectedCreateString = "create table `test_table` "
-        + "(`ID1` bigint not null,id2 varchar(255) not null,"
-        + "`boolColumn` boolean,longVal bigint not null,stringVal varchar(255)) "
+        + "(`ID1` INT64 not null,id2 STRING(255) not null,"
+        + "`boolColumn` BOOL,longVal INT64 not null,stringVal STRING(255)) "
         + "PRIMARY KEY (`ID1`,id2)";
 
     assertThat(statements.get(0)).isEqualTo(expectedCreateString);
@@ -110,30 +110,22 @@ public class SpannerTableExporterTests {
 
   @Test
   public void generateCreateStringsEmptyEntityTest() {
-    Metadata metadata = new MetadataSources(this.registry)
-        .addAnnotatedClass(EmptyEntity.class)
-        .buildMetadata();
-
     assertThatThrownBy(() ->
-        new SchemaExport()
-            .setOutputFile("unused")
-            .createOnly(EnumSet.of(TargetType.STDOUT, TargetType.SCRIPT), metadata))
+        new MetadataSources(this.registry)
+            .addAnnotatedClass(EmptyEntity.class)
+            .buildMetadata())
         .isInstanceOf(AnnotationException.class)
-        .hasMessage("No identifier specified for entity:");
+        .hasMessageContaining("No identifier specified for entity:");
   }
 
   @Test
   public void generateCreateStringsNoPkEntityTest() {
-    Metadata metadata = new MetadataSources(this.registry)
-        .addAnnotatedClass(NoPkEntity.class)
-        .buildMetadata();
-
     assertThatThrownBy(() ->
-        new SchemaExport()
-            .setOutputFile("unused")
-            .createOnly(EnumSet.of(TargetType.STDOUT, TargetType.SCRIPT), metadata))
+        new MetadataSources(this.registry)
+            .addAnnotatedClass(NoPkEntity.class)
+            .buildMetadata())
         .isInstanceOf(AnnotationException.class)
-        .hasMessage("No identifier specified for entity:");
+        .hasMessageContaining("No identifier specified for entity:");
   }
 
   @Entity


### PR DESCRIPTION
This fixes several tests and updates pom.xml so the tests get run.

Several tests were broken because they were not getting run during `mvn test`. This was due to the naming convention where tests are named `*Tests.java`; this requires an additional setting in pom.xml for the tests to get picked up by Maven and run.