### PR TITLE
Fix the test module's artifact name

### DIFF
--- a/google-cloud-spanner-hibernate-testing/pom.xml
+++ b/google-cloud-spanner-hibernate-testing/pom.xml
@@ -14,7 +14,7 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>integration-testing</artifactId>
+	<artifactId>google-cloud-spanner-hibernate-testing</artifactId>
 	<name>Google Cloud Spanner Hibernate Integration Testing</name>
 
 	<dependencies>


### PR DESCRIPTION
Rename module artifact id to `google-cloud-spanner-hibernate-testing`.