### PR TITLE
Upgrade puppycrawl to 8.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.12</version>
+            <version>8.18</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
Addresses security vulnerability in com.puppycrawl.tools:checkstyle versions which are < 8.18.