### PR TITLE
Skip integration test during basic PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - ./mvnw -T 1.5C clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -q;
 
 before_install:
-  - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
+  - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
       openssl aes-256-cbc -K $encrypted_5bb5dbfd81fd_key -iv $encrypted_5bb5dbfd81fd_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
       tar -xzf travis.tar.gz;
       export GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/travis/admin.json;


### PR DESCRIPTION
Configures the travis.yml to skip integration during a basic PR since the integration tests are starting to take a while to run.