### PR TITLE
Add code to benchmark basic Hibernate operations

### DIFF
--- a/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/ClientLibraryOperations.java
+++ b/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/ClientLibraryOperations.java
@@ -23,9 +23,11 @@ import com.google.cloud.Date;
 import com.google.cloud.spanner.DatabaseAdminClient;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
@@ -37,11 +39,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.log4j.Logger;
 
 /**
  * Runs common operations (reads, writes) on Spanner using the Spanner Client Libraries.
  */
 public class ClientLibraryOperations {
+
+  private static final Logger LOGGER = Logger.getLogger(ClientLibraryOperations.class);
+
   private static final String DDL_SMALL = "/ddl_strings/airport_ddl.txt";
   private static final String DDL_LARGE = "/ddl_strings/bulk_ddl.txt";
 
@@ -75,7 +81,16 @@ public class ClientLibraryOperations {
    * Resets the test Spanner database.
    */
   public void resetTestDatabase() {
-    databaseAdminClient.dropDatabase(INSTANCE_NAME, DATABASE_NAME);
+    try {
+      databaseAdminClient.dropDatabase(INSTANCE_NAME, DATABASE_NAME);
+    } catch (SpannerException e) {
+      if (e.getErrorCode() != ErrorCode.NOT_FOUND) {
+        throw new RuntimeException(e);
+      } else {
+        LOGGER.info("Skipping dropping the test database because it was not found.");
+      }
+    }
+
     try {
       databaseAdminClient.createDatabase(
           INSTANCE_NAME, DATABASE_NAME, Collections.EMPTY_LIST).get();

--- a/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/ClientLibraryOperations.java
+++ b/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/ClientLibraryOperations.java
@@ -72,22 +72,16 @@ public class ClientLibraryOperations {
   }
 
   /**
-   * Creates a database.
+   * Resets the test Spanner database.
    */
-  public void createTestDatabase() {
+  public void resetTestDatabase() {
+    databaseAdminClient.dropDatabase(INSTANCE_NAME, DATABASE_NAME);
     try {
       databaseAdminClient.createDatabase(
           INSTANCE_NAME, DATABASE_NAME, Collections.EMPTY_LIST).get();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-  }
-
-  /**
-   * Deletes a database.
-   */
-  public void deleteTestDatabase() {
-    databaseAdminClient.dropDatabase(INSTANCE_NAME, DATABASE_NAME);
   }
 
   /**

--- a/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/HibernateDriver.java
+++ b/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/HibernateDriver.java
@@ -18,36 +18,43 @@
 
 package com.google.cloud.spanner.hibernate;
 
-import static com.google.cloud.spanner.hibernate.BenchmarkUtil.benchmark;
-
 import org.apache.log4j.Logger;
 
 /**
- * Runs Spanner Client Library operations and benchmarks their performance.
+ * Runs and benchmarks common operations on Spanner using Hibernate.
  */
-public class ClientLibraryDriver {
+public class HibernateDriver {
 
-  private static final Logger LOGGER = Logger.getLogger(ClientLibraryDriver.class);
+  private static final Logger LOGGER = Logger.getLogger(HibernateDriver.class);
 
   /**
-   * Runs and benchmarks Spanner Client Library operations.
+   * Runs and benchmarks Hibernate operations.
    */
   public static void main(String[] args) {
+    LOGGER.info("Resetting the test database.");
     ClientLibraryOperations clientLibraryOperations = new ClientLibraryOperations();
-
-    LOGGER.info("Resetting the Spanner database to run the performance tests.");
     clientLibraryOperations.resetTestDatabase();
 
-    benchmark(clientLibraryOperations::createSingleTable, "Create a table.");
-    benchmark(
-        clientLibraryOperations::singleInsert, "Insert a record into a table.");
-    benchmark(
-        () -> clientLibraryOperations.batchInsert(1000),
-        "Insert 1000 records into a table.");
-    benchmark(
-        clientLibraryOperations::batchUpdate, "Updates 1000 records in a table.");
-    benchmark(
-        clientLibraryOperations::deleteSingleTable, "Drops a single table");
-    benchmark(clientLibraryOperations::runDdlLarge, "Running bulk DDL operations.");
+    HibernateOperations hibernateOperations = new HibernateOperations();
+
+    BenchmarkUtil.benchmark(
+        hibernateOperations::initializeEntityTables,
+        "Create 1 Spanner table from Hibernate entity classes.");
+
+    BenchmarkUtil.benchmark(
+        () -> hibernateOperations.insertRows(1),
+        "Insert a single row through persisting a Hibernate entity.");
+
+    BenchmarkUtil.benchmark(
+        () -> hibernateOperations.insertRows(1000),
+        "Insert 1000 rows by saving Hibernate entities.");
+
+    BenchmarkUtil.benchmark(
+        () -> hibernateOperations.updateRows(1),
+        "Update 1 row by saving Hibernate entities.");
+
+    BenchmarkUtil.benchmark(
+        () -> hibernateOperations.updateRows(1000),
+        "Update 1000 row by saving Hibernate entities.");
   }
 }

--- a/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/HibernateDriver.java
+++ b/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/HibernateDriver.java
@@ -55,6 +55,6 @@ public class HibernateDriver {
 
     BenchmarkUtil.benchmark(
         () -> hibernateOperations.updateRows(1000),
-        "Update 1000 row by saving Hibernate entities.");
+        "Update 1000 rows by saving Hibernate entities.");
   }
 }

--- a/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/HibernateOperations.java
+++ b/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/HibernateOperations.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate;
+
+import com.google.cloud.spanner.hibernate.entities.Airport;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.FlushModeType;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.query.Query;
+
+final class HibernateOperations {
+
+  private StandardServiceRegistry registry;
+  private SessionFactory sessionFactory;
+
+  HibernateOperations() {
+    this.registry = new StandardServiceRegistryBuilder().configure().build();
+  }
+
+  void initializeEntityTables() {
+    this.sessionFactory = new MetadataSources(registry).buildMetadata().buildSessionFactory();
+  }
+
+  void insertRows(int rowCount) {
+    Session session = this.sessionFactory.openSession();
+    session.setFlushMode(FlushModeType.COMMIT);
+
+    Transaction tx = session.beginTransaction();
+
+    for (int i = 0; i < rowCount; i++) {
+      Airport airport = new Airport(
+          "The Airport",
+          i + " main street",
+          "United States",
+          new Date(),
+          (long) (1000 * Math.random()));
+
+      session.save(airport);
+    }
+
+    tx.commit();
+    session.close();
+  }
+
+  void updateRows(int rowCount) {
+    Session session = this.sessionFactory.openSession();
+    session.setFlushMode(FlushModeType.COMMIT);
+    Transaction tx = session.beginTransaction();
+
+    CriteriaBuilder builder = session.getCriteriaBuilder();
+
+    CriteriaQuery<Airport> criteria = builder.createQuery(Airport.class);
+    Root<Airport> rootEntry = criteria.from(Airport.class);
+    criteria.select(rootEntry);
+
+    Query<Airport> airportQuery = session.createQuery(criteria);
+    List<Airport> airportList = airportQuery.stream().limit(rowCount).collect(Collectors.toList());
+
+    for (Airport airport : airportList) {
+      airport.setCountry("Canada");
+      airport.setPlaneCapacity((long) (Math.random() * 10000));
+      session.update(airport);
+    }
+
+    tx.commit();
+    session.close();
+  }
+}

--- a/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/HibernateOperations.java
+++ b/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/HibernateOperations.java
@@ -56,7 +56,7 @@ final class HibernateOperations {
     for (int i = 0; i < rowCount; i++) {
       Airport airport = new Airport(
           "The Airport",
-          i + " main street",
+          "100 main street",
           "United States",
           new Date(),
           (long) (1000 * Math.random()));

--- a/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/entities/Airport.java
+++ b/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/entities/Airport.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate.entities;
+
+import java.util.Date;
+import java.util.UUID;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import org.hibernate.annotations.Type;
+
+/**
+ * A simple Hibernate entity for performance testing.
+ */
+@Entity
+public class Airport {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  @Type(type = "uuid-char")
+  private UUID id;
+
+  private String name;
+
+  private String address;
+
+  private String country;
+
+  private Date dateBuilt;
+
+  private long planeCapacity;
+
+  /**
+   * Constructs the Airport Hibernate test entity.
+   */
+  public Airport(String name, String address, String country, Date dateBuilt, long planeCapacity) {
+    this.name = name;
+    this.address = address;
+    this.country = country;
+    this.dateBuilt = dateBuilt;
+    this.planeCapacity = planeCapacity;
+  }
+
+  /**
+   * Default entity constructor for Hibernate.
+   */
+  public Airport() {}
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getAddress() {
+    return address;
+  }
+
+  public void setAddress(String address) {
+    this.address = address;
+  }
+
+  public String getCountry() {
+    return country;
+  }
+
+  public void setCountry(String country) {
+    this.country = country;
+  }
+
+  public Date getDateBuilt() {
+    return dateBuilt;
+  }
+
+  public void setDateBuilt(Date dateBuilt) {
+    this.dateBuilt = dateBuilt;
+  }
+
+  public long getPlaneCapacity() {
+    return planeCapacity;
+  }
+
+  public void setPlaneCapacity(long planeCapacity) {
+    this.planeCapacity = planeCapacity;
+  }
+}

--- a/google-cloud-spanner-hibernate-performance-testing/src/main/resources/hibernate.cfg.xml
+++ b/google-cloud-spanner-hibernate-performance-testing/src/main/resources/hibernate.cfg.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-configuration PUBLIC
+  "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+  "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+  <session-factory>
+
+    <!-- [START spanner_hibernate_config] -->
+    <!-- Connection settings -->
+    <property name="hibernate.dialect">com.google.cloud.spanner.hibernate.SpannerDialect</property>
+    <property name="hibernate.connection.driver_class">com.google.cloud.spanner.jdbc.JdbcDriver</property>
+    <property name="hibernate.connection.url">jdbc:cloudspanner:/projects/cloud-spanner-hibernate-ci/instances/test-instance/databases/hibernate-performance-testing</property>
+    <!-- [END spanner_hibernate_config] -->
+
+    <!-- Update database on startup -->
+    <property name="hibernate.hbm2ddl.auto">update</property>
+
+    <mapping class="com.google.cloud.spanner.hibernate.entities.Airport"/>
+
+  </session-factory>
+</hibernate-configuration>


### PR DESCRIPTION
This adds code to begin benchmarking some basic Hibernate operations.

More operations will be added, such as bulk DDL; this is not a complete list.