### PR TITLE
Implement Batched DDL Statements

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerServiceContributor.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerServiceContributor.java
@@ -18,8 +18,13 @@
 
 package com.google.cloud.spanner.hibernate;
 
+import com.google.cloud.spanner.hibernate.schema.SpannerSchemaManagementTool;
+import java.util.Map;
+import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.service.spi.ServiceContributor;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.tool.schema.spi.SchemaManagementTool;
 
 /**
  * An implementation of a Hibernate {@link ServiceContributor} which provides a "userAgent" JDBC
@@ -32,10 +37,26 @@ import org.hibernate.service.spi.ServiceContributor;
  */
 public class SpannerServiceContributor implements ServiceContributor {
 
+  private static final SpannerSchemaManagementTool SCHEMA_MANAGEMENT_TOOL = new SpannerSchemaManagementTool();
+
   static final String HIBERNATE_API_CLIENT_LIB_TOKEN = "sp-hib";
 
   public void contribute(StandardServiceRegistryBuilder serviceRegistryBuilder) {
     serviceRegistryBuilder
-        .applySetting("hibernate.connection.userAgent", HIBERNATE_API_CLIENT_LIB_TOKEN);
+        .applySetting("hibernate.connection.userAgent", HIBERNATE_API_CLIENT_LIB_TOKEN)
+        .addInitiator(
+            new StandardServiceInitiator<SchemaManagementTool>() {
+              @Override
+              public Class<SchemaManagementTool> getServiceInitiated() {
+                return SchemaManagementTool.class;
+              }
+
+              @Override
+              public SpannerSchemaManagementTool initiateService(Map configurationValues,
+                  ServiceRegistryImplementor registry) {
+                return SCHEMA_MANAGEMENT_TOOL;
+              }
+            }
+        );
   }
 }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerServiceContributor.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerServiceContributor.java
@@ -37,10 +37,12 @@ import org.hibernate.tool.schema.spi.SchemaManagementTool;
  */
 public class SpannerServiceContributor implements ServiceContributor {
 
-  private static final SpannerSchemaManagementTool SCHEMA_MANAGEMENT_TOOL = new SpannerSchemaManagementTool();
+  private static final SpannerSchemaManagementTool SCHEMA_MANAGEMENT_TOOL =
+      new SpannerSchemaManagementTool();
 
   static final String HIBERNATE_API_CLIENT_LIB_TOKEN = "sp-hib";
 
+  @Override
   public void contribute(StandardServiceRegistryBuilder serviceRegistryBuilder) {
     serviceRegistryBuilder
         .applySetting("hibernate.connection.userAgent", HIBERNATE_API_CLIENT_LIB_TOKEN)
@@ -52,11 +54,10 @@ public class SpannerServiceContributor implements ServiceContributor {
               }
 
               @Override
-              public SpannerSchemaManagementTool initiateService(Map configurationValues,
-                  ServiceRegistryImplementor registry) {
+              public SpannerSchemaManagementTool initiateService(
+                  Map configurationValues, ServiceRegistryImplementor registry) {
                 return SCHEMA_MANAGEMENT_TOOL;
               }
-            }
-        );
+            });
   }
 }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerServiceContributor.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerServiceContributor.java
@@ -19,16 +19,12 @@
 package com.google.cloud.spanner.hibernate;
 
 import com.google.cloud.spanner.hibernate.schema.SpannerSchemaManagementTool;
-import java.util.Map;
-import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.service.spi.ServiceContributor;
-import org.hibernate.service.spi.ServiceRegistryImplementor;
-import org.hibernate.tool.schema.spi.SchemaManagementTool;
 
 /**
- * An implementation of a Hibernate {@link ServiceContributor} which provides a "userAgent" JDBC
- * connection property to the Spanner JDBC driver to identify the library.
+ * An implementation of a Hibernate {@link ServiceContributor} which provides custom settings
+ * for the Spanner Hibernate dialect.
  *
  * <p>Note that Hibernate will automatically pass down all "hibernate.connection.*" properties
  * without the prefix to {@code Driver.connect(url, props)}.
@@ -45,19 +41,9 @@ public class SpannerServiceContributor implements ServiceContributor {
   @Override
   public void contribute(StandardServiceRegistryBuilder serviceRegistryBuilder) {
     serviceRegistryBuilder
+        // The user agent JDBC connection property to identify the library.
         .applySetting("hibernate.connection.userAgent", HIBERNATE_API_CLIENT_LIB_TOKEN)
-        .addInitiator(
-            new StandardServiceInitiator<SchemaManagementTool>() {
-              @Override
-              public Class<SchemaManagementTool> getServiceInitiated() {
-                return SchemaManagementTool.class;
-              }
-
-              @Override
-              public SpannerSchemaManagementTool initiateService(
-                  Map configurationValues, ServiceRegistryImplementor registry) {
-                return SCHEMA_MANAGEMENT_TOOL;
-              }
-            });
+        // The custom Hibernate schema management tool for Spanner.
+        .applySetting("hibernate.schema_management_tool", SCHEMA_MANAGEMENT_TOOL);
   }
 }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/RunBatchDdl.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/RunBatchDdl.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
 package com.google.cloud.spanner.hibernate.schema;
 
 import com.google.cloud.spanner.hibernate.SpannerDialect;

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/RunBatchDdl.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/RunBatchDdl.java
@@ -1,0 +1,37 @@
+package com.google.cloud.spanner.hibernate.schema;
+
+import com.google.cloud.spanner.hibernate.SpannerDialect;
+import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
+import org.hibernate.dialect.Dialect;
+
+/**
+ * Custom {@link AuxiliaryDatabaseObject} which generates the RUN BATCH statement.
+ */
+public class RunBatchDdl implements AuxiliaryDatabaseObject {
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public String getExportIdentifier() {
+    return "RUN_BATCH_DDL";
+  }
+
+  @Override
+  public boolean appliesToDialect(Dialect dialect) {
+    return SpannerDialect.class.isAssignableFrom(dialect.getClass());
+  }
+
+  @Override
+  public boolean beforeTablesOnCreation() {
+    return false;
+  }
+
+  @Override
+  public String[] sqlCreateStrings(Dialect dialect) {
+    return new String[] {"RUN BATCH"};
+  }
+
+  @Override
+  public String[] sqlDropStrings(Dialect dialect) {
+    return new String[] {"RUN BATCH"};
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaCreator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaCreator.java
@@ -19,10 +19,9 @@
 package com.google.cloud.spanner.hibernate.schema;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.tool.schema.internal.HibernateSchemaManagementTool;
 import org.hibernate.tool.schema.internal.SchemaCreatorImpl;
 import org.hibernate.tool.schema.spi.ExecutionOptions;
-import org.hibernate.tool.schema.spi.SchemaFilter;
+import org.hibernate.tool.schema.spi.SchemaCreator;
 import org.hibernate.tool.schema.spi.SourceDescriptor;
 import org.hibernate.tool.schema.spi.TargetDescriptor;
 
@@ -30,11 +29,12 @@ import org.hibernate.tool.schema.spi.TargetDescriptor;
  * A modified version of the {@link SchemaCreatorImpl} which batches DDL statements
  * to optimize performance.
  */
-public class SpannerSchemaCreator extends SchemaCreatorImpl {
+public class SpannerSchemaCreator implements SchemaCreator {
 
-  public SpannerSchemaCreator(
-      HibernateSchemaManagementTool tool, SchemaFilter schemaFilter) {
-    super(tool, schemaFilter);
+  private final SchemaCreator schemaCreator;
+
+  public SpannerSchemaCreator(SchemaCreator schemaCreator) {
+    this.schemaCreator = schemaCreator;
   }
 
   @Override
@@ -43,9 +43,9 @@ public class SpannerSchemaCreator extends SchemaCreatorImpl {
       ExecutionOptions options,
       SourceDescriptor sourceDescriptor,
       TargetDescriptor targetDescriptor) {
+
     metadata.getDatabase().addAuxiliaryDatabaseObject(new StartBatchDdl());
     metadata.getDatabase().addAuxiliaryDatabaseObject(new RunBatchDdl());
-
-    super.doCreation(metadata, options, sourceDescriptor, targetDescriptor);
+    schemaCreator.doCreation(metadata, options, sourceDescriptor, targetDescriptor);
   }
 }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaCreator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaCreator.java
@@ -1,0 +1,36 @@
+package com.google.cloud.spanner.hibernate.schema;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.internal.Formatter;
+import org.hibernate.tool.schema.internal.HibernateSchemaManagementTool;
+import org.hibernate.tool.schema.internal.SchemaCreatorImpl;
+import org.hibernate.tool.schema.internal.exec.GenerationTarget;
+import org.hibernate.tool.schema.spi.ExecutionOptions;
+import org.hibernate.tool.schema.spi.SchemaFilter;
+import org.hibernate.tool.schema.spi.SourceDescriptor;
+import org.hibernate.tool.schema.spi.TargetDescriptor;
+
+/**
+ * A modified version of the {@link SchemaCreatorImpl} which batches DDL statements
+ * to optimize performance.
+ */
+public class SpannerSchemaCreator extends SchemaCreatorImpl {
+
+  public SpannerSchemaCreator(
+      HibernateSchemaManagementTool tool, SchemaFilter schemaFilter) {
+    super(tool, schemaFilter);
+  }
+
+  @Override
+  public void doCreation(
+      Metadata metadata,
+      ExecutionOptions options,
+      SourceDescriptor sourceDescriptor,
+      TargetDescriptor targetDescriptor) {
+    metadata.getDatabase().addAuxiliaryDatabaseObject(new StartBatchDdl());
+    metadata.getDatabase().addAuxiliaryDatabaseObject(new RunBatchDdl());
+
+    super.doCreation(metadata, options, sourceDescriptor, targetDescriptor);
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaCreator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaCreator.java
@@ -1,11 +1,26 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
 package com.google.cloud.spanner.hibernate.schema;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.dialect.Dialect;
-import org.hibernate.engine.jdbc.internal.Formatter;
 import org.hibernate.tool.schema.internal.HibernateSchemaManagementTool;
 import org.hibernate.tool.schema.internal.SchemaCreatorImpl;
-import org.hibernate.tool.schema.internal.exec.GenerationTarget;
 import org.hibernate.tool.schema.spi.ExecutionOptions;
 import org.hibernate.tool.schema.spi.SchemaFilter;
 import org.hibernate.tool.schema.spi.SourceDescriptor;

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaDropper.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaDropper.java
@@ -1,11 +1,26 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
 package com.google.cloud.spanner.hibernate.schema;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.dialect.Dialect;
 import org.hibernate.tool.schema.internal.HibernateSchemaManagementTool;
 import org.hibernate.tool.schema.internal.SchemaDropperImpl;
-import org.hibernate.tool.schema.internal.exec.GenerationTarget;
-import org.hibernate.tool.schema.internal.exec.JdbcContext;
 import org.hibernate.tool.schema.spi.ExecutionOptions;
 import org.hibernate.tool.schema.spi.SchemaFilter;
 import org.hibernate.tool.schema.spi.SourceDescriptor;

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaDropper.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaDropper.java
@@ -1,0 +1,35 @@
+package com.google.cloud.spanner.hibernate.schema;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.tool.schema.internal.HibernateSchemaManagementTool;
+import org.hibernate.tool.schema.internal.SchemaDropperImpl;
+import org.hibernate.tool.schema.internal.exec.GenerationTarget;
+import org.hibernate.tool.schema.internal.exec.JdbcContext;
+import org.hibernate.tool.schema.spi.ExecutionOptions;
+import org.hibernate.tool.schema.spi.SchemaFilter;
+import org.hibernate.tool.schema.spi.SourceDescriptor;
+import org.hibernate.tool.schema.spi.TargetDescriptor;
+
+/**
+ * A modified version of the {@link SchemaDropperImpl} which batches DDL statements
+ * to optimize performance.
+ */
+public class SpannerSchemaDropper extends SchemaDropperImpl {
+
+  public SpannerSchemaDropper(HibernateSchemaManagementTool tool, SchemaFilter schemaFilter) {
+    super(tool, schemaFilter);
+  }
+
+  @Override
+  public void doDrop(
+      Metadata metadata,
+      ExecutionOptions options,
+      SourceDescriptor sourceDescriptor,
+      TargetDescriptor targetDescriptor) {
+    metadata.getDatabase().addAuxiliaryDatabaseObject(new StartBatchDdl());
+    metadata.getDatabase().addAuxiliaryDatabaseObject(new RunBatchDdl());
+
+    super.doDrop(metadata, options, sourceDescriptor, targetDescriptor);
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaManagementTool.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaManagementTool.java
@@ -1,0 +1,38 @@
+package com.google.cloud.spanner.hibernate.schema;
+
+import java.util.Map;
+import org.hibernate.boot.registry.selector.spi.StrategySelector;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.tool.schema.internal.DefaultSchemaFilterProvider;
+import org.hibernate.tool.schema.internal.HibernateSchemaManagementTool;
+import org.hibernate.tool.schema.spi.SchemaCreator;
+import org.hibernate.tool.schema.spi.SchemaDropper;
+import org.hibernate.tool.schema.spi.SchemaFilterProvider;
+
+public class SpannerSchemaManagementTool extends HibernateSchemaManagementTool {
+
+  @Override
+  public SchemaCreator getSchemaCreator(Map options) {
+    return new SpannerSchemaCreator(this, getSchemaFilterProvider(options).getCreateFilter());
+  }
+
+  @Override
+  public SchemaDropper getSchemaDropper(Map options) {
+    return new SpannerSchemaDropper(this, getSchemaFilterProvider(options).getCreateFilter());
+  }
+
+  /**
+   * Returns the {@link SchemaFilterProvider} used for creating the Schema creator and dropper.
+   */
+  private SchemaFilterProvider getSchemaFilterProvider(Map options) {
+    final Object configuredOption = (options == null)
+        ? null
+        : options.get( AvailableSettings.HBM2DDL_FILTER_PROVIDER );
+
+    return getServiceRegistry().getService(StrategySelector.class)
+        .resolveDefaultableStrategy(
+            SchemaFilterProvider.class,
+            configuredOption,
+            DefaultSchemaFilterProvider.INSTANCE);
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaManagementTool.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaManagementTool.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
 package com.google.cloud.spanner.hibernate.schema;
 
 import java.util.Map;
@@ -27,7 +45,7 @@ public class SpannerSchemaManagementTool extends HibernateSchemaManagementTool {
   private SchemaFilterProvider getSchemaFilterProvider(Map options) {
     final Object configuredOption = (options == null)
         ? null
-        : options.get( AvailableSettings.HBM2DDL_FILTER_PROVIDER );
+        : options.get(AvailableSettings.HBM2DDL_FILTER_PROVIDER);
 
     return getServiceRegistry().getService(StrategySelector.class)
         .resolveDefaultableStrategy(

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaManagementTool.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaManagementTool.java
@@ -19,38 +19,23 @@
 package com.google.cloud.spanner.hibernate.schema;
 
 import java.util.Map;
-import org.hibernate.boot.registry.selector.spi.StrategySelector;
-import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.tool.schema.internal.DefaultSchemaFilterProvider;
 import org.hibernate.tool.schema.internal.HibernateSchemaManagementTool;
 import org.hibernate.tool.schema.spi.SchemaCreator;
 import org.hibernate.tool.schema.spi.SchemaDropper;
-import org.hibernate.tool.schema.spi.SchemaFilterProvider;
 
+/**
+ * The custom implementation of {@link HibernateSchemaManagementTool} for Spanner to support batched
+ * DDL statements.
+ */
 public class SpannerSchemaManagementTool extends HibernateSchemaManagementTool {
 
   @Override
   public SchemaCreator getSchemaCreator(Map options) {
-    return new SpannerSchemaCreator(this, getSchemaFilterProvider(options).getCreateFilter());
+    return new SpannerSchemaCreator(super.getSchemaCreator(options));
   }
 
   @Override
   public SchemaDropper getSchemaDropper(Map options) {
-    return new SpannerSchemaDropper(this, getSchemaFilterProvider(options).getCreateFilter());
-  }
-
-  /**
-   * Returns the {@link SchemaFilterProvider} used for creating the Schema creator and dropper.
-   */
-  private SchemaFilterProvider getSchemaFilterProvider(Map options) {
-    final Object configuredOption = (options == null)
-        ? null
-        : options.get(AvailableSettings.HBM2DDL_FILTER_PROVIDER);
-
-    return getServiceRegistry().getService(StrategySelector.class)
-        .resolveDefaultableStrategy(
-            SchemaFilterProvider.class,
-            configuredOption,
-            DefaultSchemaFilterProvider.INSTANCE);
+    return new SpannerSchemaDropper(super.getSchemaDropper(options));
   }
 }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/StartBatchDdl.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/StartBatchDdl.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
 package com.google.cloud.spanner.hibernate.schema;
 
 import com.google.cloud.spanner.hibernate.SpannerDialect;

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/StartBatchDdl.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/StartBatchDdl.java
@@ -1,0 +1,37 @@
+package com.google.cloud.spanner.hibernate.schema;
+
+import com.google.cloud.spanner.hibernate.SpannerDialect;
+import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
+import org.hibernate.dialect.Dialect;
+
+/**
+ * Custom {@link AuxiliaryDatabaseObject} which generates the START BATCH DDL statement.
+ */
+public class StartBatchDdl implements AuxiliaryDatabaseObject {
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public String getExportIdentifier() {
+    return "START_BATCH_DDL";
+  }
+
+  @Override
+  public boolean appliesToDialect(Dialect dialect) {
+    return SpannerDialect.class.isAssignableFrom(dialect.getClass());
+  }
+
+  @Override
+  public boolean beforeTablesOnCreation() {
+    return true;
+  }
+
+  @Override
+  public String[] sqlCreateStrings(Dialect dialect) {
+    return new String[] {"START BATCH DDL"};
+  }
+
+  @Override
+  public String[] sqlDropStrings(Dialect dialect) {
+    return new String[] {"START BATCH DDL"};
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
@@ -74,13 +74,18 @@ public class GeneratedCreateTableStatementsTests {
         .getExecutedStatements();
 
     assertThat(sqlStrings).containsExactly(
+        "START BATCH DDL",
         "drop index name_index",
         "drop table Employee",
         "drop table hibernate_sequence",
+        "RUN BATCH",
+        "START BATCH DDL",
         "create table Employee "
             + "(id INT64 not null,name STRING(255),manager_id INT64) PRIMARY KEY (id)",
         "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
         "INSERT INTO hibernate_sequence (next_val) VALUES(1)",
-        "create index name_index on Employee (name)");
+        "create index name_index on Employee (name)",
+        "RUN BATCH"
+    );
   }
 }

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
@@ -71,7 +71,11 @@ public class SpannerTableExporterTests {
     scriptFile.deleteOnExit();
     List<String> statements = Files.readAllLines(scriptFile.toPath());
     assertThat(statements)
-        .containsExactly("drop table `TestEntity_stringList`", "drop table `test_table`");
+        .containsExactly(
+            "START BATCH DDL",
+            "drop table `TestEntity_stringList`",
+            "drop table `test_table`",
+            "RUN BATCH");
   }
 
   @Test
@@ -86,8 +90,12 @@ public class SpannerTableExporterTests {
     scriptFile.deleteOnExit();
     List<String> statements = Files.readAllLines(scriptFile.toPath());
 
-    assertThat(statements).containsExactly("drop index name_index", "drop table Employee",
-        "drop table hibernate_sequence");
+    assertThat(statements).containsExactly(
+        "START BATCH DDL",
+        "drop index name_index",
+        "drop table Employee",
+        "drop table hibernate_sequence",
+        "RUN BATCH");
   }
 
   @Test
@@ -109,8 +117,10 @@ public class SpannerTableExporterTests {
         + "(`TestEntity_ID1` INT64 not null,`TestEntity_id2` STRING(255) not null,"
         + "stringList STRING(255)) PRIMARY KEY (`TestEntity_ID1`,`TestEntity_id2`,stringList)";
 
-    assertThat(statements)
+    assertThat(statements.get(0)).isEqualTo("START BATCH DDL");
+    assertThat(statements.subList(1, 3))
         .containsExactlyInAnyOrder(expectedCreateString, expectedCollectionCreateString);
+    assertThat(statements.get(3)).isEqualTo("RUN BATCH");
   }
 
   @Test

--- a/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/bulkddl/BulkDdlDriver.java
+++ b/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/bulkddl/BulkDdlDriver.java
@@ -23,7 +23,6 @@ import com.google.cloud.spanner.hibernate.ClientLibraryOperations;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.log4j.Logger;
-import org.hibernate.boot.MetadataSources;
 import org.hibernate.cfg.Configuration;
 
 /**
@@ -46,7 +45,7 @@ public class BulkDdlDriver {
   public static void main(String[] args) {
     LOGGER.info("Resetting the Spanner test database.");
     ClientLibraryOperations clientLibraryOperations = new ClientLibraryOperations();
-    // clientLibraryOperations.resetTestDatabase();
+    clientLibraryOperations.resetTestDatabase();
 
     Configuration configuration = new Configuration()
         .configure("hibernate.cfg.xml")

--- a/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/bulkddl/BulkDdlDriver.java
+++ b/google-cloud-spanner-hibernate-performance-testing/src/main/java/com/google/cloud/spanner/hibernate/bulkddl/BulkDdlDriver.java
@@ -23,6 +23,7 @@ import com.google.cloud.spanner.hibernate.ClientLibraryOperations;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.log4j.Logger;
+import org.hibernate.boot.MetadataSources;
 import org.hibernate.cfg.Configuration;
 
 /**
@@ -45,7 +46,7 @@ public class BulkDdlDriver {
   public static void main(String[] args) {
     LOGGER.info("Resetting the Spanner test database.");
     ClientLibraryOperations clientLibraryOperations = new ClientLibraryOperations();
-    clientLibraryOperations.resetTestDatabase();
+    // clientLibraryOperations.resetTestDatabase();
 
     Configuration configuration = new Configuration()
         .configure("hibernate.cfg.xml")


### PR DESCRIPTION
Implements batched DDL statements for schema creation and dropping.

This is achieved by providing implementations of `SpannerSchemaCreator` and `SpannerSchemaDropper` which are registered by the `SpannerSchemaManagementTool`. The `StartBatchDdl` and `RunBatchDdl` are auxiliary database objects which generate the batched DDL statements before and after table creation.

See test cases for examples. The DDL statements are now wrapped in between the start batch and run batch statements.
```
"START BATCH DDL",
"drop table `TestEntity_stringList`",
"drop table `test_table`",
"RUN BATCH"
```

Pending discussion with Hibernate folks on how to best integrate batched DDL statements for schema update operations.