### PR TITLE
Move setting the Bulk ID strategy to the service contributor

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerServiceContributor.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerServiceContributor.java
@@ -20,6 +20,7 @@ package com.google.cloud.spanner.hibernate;
 
 import com.google.cloud.spanner.hibernate.schema.SpannerSchemaManagementTool;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.hql.spi.id.inline.InlineIdsOrClauseBulkIdStrategy;
 import org.hibernate.service.spi.ServiceContributor;
 
 /**
@@ -44,6 +45,8 @@ public class SpannerServiceContributor implements ServiceContributor {
         // The user agent JDBC connection property to identify the library.
         .applySetting("hibernate.connection.userAgent", HIBERNATE_API_CLIENT_LIB_TOKEN)
         // The custom Hibernate schema management tool for Spanner.
-        .applySetting("hibernate.schema_management_tool", SCHEMA_MANAGEMENT_TOOL);
+        .applySetting("hibernate.schema_management_tool", SCHEMA_MANAGEMENT_TOOL)
+        // Allows entities to be used with InheritanceType.JOINED in Spanner.
+        .applySetting("hibernate.hql.bulk_id_strategy", InlineIdsOrClauseBulkIdStrategy.INSTANCE);
   }
 }

--- a/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/src/main/resources/hibernate.cfg.xml
+++ b/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/src/main/resources/hibernate.cfg.xml
@@ -24,9 +24,6 @@
     <!-- Update database on startup -->
     <property name="hibernate.hbm2ddl.auto">create</property>
 
-    <!-- Modify the default bulk id strategy if using InheritanceType.JOINED with Spanner. -->
-    <property name="hibernate.hql.bulk_id_strategy">org.hibernate.hql.spi.id.inline.InlineIdsOrClauseBulkIdStrategy</property>
-
     <!-- Annotated entity classes -->
     <mapping class="com.example.Person"/>
     <mapping class="com.example.Payment"/>


### PR DESCRIPTION
This moves the setting of the Bulk ID strategy to the service contributor so users do not have to worry about setting it manually in configuration.