### PR TITLE
Remove undefined autoReleaseAfterClose property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,6 @@
           <configuration>
             <serverId>ossrh</serverId>
             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-            <autoReleaseAfterClose>${deploy.autorelease}</autoReleaseAfterClose>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Default is `false`. And that's what we want so that repository staging doesn't automatically release to Maven Central.