### PR TITLE
Fix the Spanner Client Lib dependency versions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,7 @@ Maven coordinates for the official https://cloud.google.com/spanner/docs/open-so
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-jdbc</artifactId>
-  <version>1.11.0</version>
+  <version>1.12.0</version>
 </dependency>
 ----
 

--- a/google-cloud-spanner-hibernate-performance-testing/pom.xml
+++ b/google-cloud-spanner-hibernate-performance-testing/pom.xml
@@ -31,11 +31,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-spanner</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
     <hibernate.version>5.4.9.Final</hibernate.version>
     <spanner-jdbc-driver.version>1.12.0</spanner-jdbc-driver.version>
     <log4j.version>1.2.17</log4j.version>
-    <google-cloud-spanner.version>1.43.0</google-cloud-spanner.version>
   </properties>
 
   <name>Google Cloud Spanner Dialect for Hibernate ORM Parent</name>
@@ -110,11 +109,6 @@
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner-jdbc</artifactId>
         <version>${spanner-jdbc-driver.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-spanner</artifactId>
-        <version>${google-cloud-spanner.version}</version>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>


### PR DESCRIPTION
The JDBC driver and Spanner Client Library versions must be in sync.

This removes the spanner dependency from the pom so that we simply rely on the spanner client lib version provided through the JDBC driver.