### PR TITLE
Check existence of tables/indices before Schema create/delete

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerTableExporter.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerTableExporter.java
@@ -69,7 +69,7 @@ public class SpannerTableExporter implements Exporter<Table> {
   /**
    * Initializes the table exporter for if a new create-table or drop-table sequence is starting.
    */
-  public void initializeTableExporter(
+  public void init(
       Metadata metadata,
       SpannerDatabaseInfo spannerDatabaseInfo,
       Action schemaAction) {

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerTableExporter.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerTableExporter.java
@@ -18,6 +18,7 @@
 
 package com.google.cloud.spanner.hibernate;
 
+import com.google.cloud.spanner.hibernate.schema.SpannerDatabaseInfo;
 import com.google.cloud.spanner.hibernate.schema.SpannerTableStatements;
 import com.google.cloud.spanner.hibernate.schema.TableDependencyTracker;
 import java.util.Collection;
@@ -68,8 +69,12 @@ public class SpannerTableExporter implements Exporter<Table> {
   /**
    * Initializes the table exporter for if a new create-table or drop-table sequence is starting.
    */
-  public void initializeTableExporter(Metadata metadata, Action schemaAction) {
+  public void initializeTableExporter(
+      Metadata metadata,
+      SpannerDatabaseInfo spannerDatabaseInfo,
+      Action schemaAction) {
     tableDependencyTracker.initializeDependencies(metadata, schemaAction);
+    spannerTableStatements.initializeSpannerDatabaseInfo(spannerDatabaseInfo);
   }
 
   private String[] buildSqlStrings(Table currentTable, Metadata metadata, Action schemaAction) {

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerDatabaseInfo.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerDatabaseInfo.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate.schema;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Helper class for extracting information from the {@link DatabaseMetaData} which contains
+ * information about what tables and indices currently exist in the database.
+ */
+public class SpannerDatabaseInfo {
+
+  private final Set<String> tableNames;
+
+  private final Set<String> indexNames;
+
+  public SpannerDatabaseInfo(DatabaseMetaData databaseMetaData) throws SQLException {
+    this.tableNames = extractDatabaseTables(databaseMetaData);
+    this.indexNames = extractDatabaseIndices(databaseMetaData);
+  }
+
+  public Set<String> getAllTables() {
+    return tableNames;
+  }
+
+  public Set<String> getAllIndices() {
+    return indexNames;
+  }
+
+  private static Set<String> extractDatabaseTables(DatabaseMetaData databaseMetaData)
+      throws SQLException {
+    HashSet<String> result = new HashSet<String>();
+
+    // Passing all null parameters will get all the tables and apply no filters.
+    ResultSet resultSet = databaseMetaData.getTables(
+        null, null, null, null);
+    while (resultSet.next()) {
+      String type = resultSet.getString("TABLE_TYPE");
+      if (type.equals("TABLE")) {
+        result.add(resultSet.getString("TABLE_NAME"));
+      }
+    }
+    resultSet.close();
+
+    return result;
+  }
+
+  private static Set<String> extractDatabaseIndices(DatabaseMetaData databaseMetaData)
+      throws SQLException {
+    HashSet<String> result = new HashSet<>();
+    ResultSet indexResultSet = databaseMetaData.getIndexInfo(
+        null, null, null, false, false);
+
+    while (indexResultSet.next()) {
+      String name = indexResultSet.getString("INDEX_NAME");
+      result.add(name);
+    }
+    indexResultSet.close();
+
+    return result;
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaCreator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaCreator.java
@@ -52,7 +52,7 @@ public class SpannerSchemaCreator implements SchemaCreator {
     metadata.getDatabase().addAuxiliaryDatabaseObject(new RunBatchDdl(Action.CREATE));
 
     // Initialize exporters with interleave dependencies so tables are created in the right order.
-    tool.getSpannerTableExporter(options).initializeTableExporter(
+    tool.getSpannerTableExporter(options).init(
         metadata, tool.getDatabaseMetaData(options), Action.CREATE);
 
     schemaCreator.doCreation(metadata, options, sourceDescriptor, targetDescriptor);

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaCreator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaCreator.java
@@ -52,7 +52,8 @@ public class SpannerSchemaCreator implements SchemaCreator {
     metadata.getDatabase().addAuxiliaryDatabaseObject(new RunBatchDdl(Action.CREATE));
 
     // Initialize exporters with interleave dependencies so tables are created in the right order.
-    tool.getSpannerTableExporter(options).initializeTableExporter(metadata, Action.CREATE);
+    tool.getSpannerTableExporter(options).initializeTableExporter(
+        metadata, tool.getDatabaseMetaData(options), Action.CREATE);
 
     schemaCreator.doCreation(metadata, options, sourceDescriptor, targetDescriptor);
   }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaDropper.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaDropper.java
@@ -53,7 +53,7 @@ public class SpannerSchemaDropper implements SchemaDropper {
     metadata.getDatabase().addAuxiliaryDatabaseObject(new RunBatchDdl(Action.DROP));
 
     // Initialize exporters with drop table dependencies so tables are dropped in the right order.
-    tool.getSpannerTableExporter(options).initializeTableExporter(
+    tool.getSpannerTableExporter(options).init(
         metadata,
         tool.getDatabaseMetaData(options),
         Action.DROP);
@@ -66,7 +66,7 @@ public class SpannerSchemaDropper implements SchemaDropper {
       Metadata metadata, ExecutionOptions options, SourceDescriptor sourceDescriptor) {
 
     // Initialize exporters with drop table dependencies so tables are dropped in the right order.
-    tool.getSpannerTableExporter(options).initializeTableExporter(
+    tool.getSpannerTableExporter(options).init(
         metadata, tool.getDatabaseMetaData(options), Action.DROP);
 
     return schemaDropper.buildDelayedAction(metadata, options, sourceDescriptor);

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaDropper.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaDropper.java
@@ -53,7 +53,10 @@ public class SpannerSchemaDropper implements SchemaDropper {
     metadata.getDatabase().addAuxiliaryDatabaseObject(new RunBatchDdl(Action.DROP));
 
     // Initialize exporters with drop table dependencies so tables are dropped in the right order.
-    tool.getSpannerTableExporter(options).initializeTableExporter(metadata, Action.DROP);
+    tool.getSpannerTableExporter(options).initializeTableExporter(
+        metadata,
+        tool.getDatabaseMetaData(options),
+        Action.DROP);
 
     schemaDropper.doDrop(metadata, options, sourceDescriptor, targetDescriptor);
   }
@@ -63,7 +66,8 @@ public class SpannerSchemaDropper implements SchemaDropper {
       Metadata metadata, ExecutionOptions options, SourceDescriptor sourceDescriptor) {
 
     // Initialize exporters with drop table dependencies so tables are dropped in the right order.
-    tool.getSpannerTableExporter(options).initializeTableExporter(metadata, Action.DROP);
+    tool.getSpannerTableExporter(options).initializeTableExporter(
+        metadata, tool.getDatabaseMetaData(options), Action.DROP);
 
     return schemaDropper.buildDelayedAction(metadata, options, sourceDescriptor);
   }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaManagementTool.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaManagementTool.java
@@ -19,7 +19,10 @@
 package com.google.cloud.spanner.hibernate.schema;
 
 import com.google.cloud.spanner.hibernate.SpannerTableExporter;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
 import java.util.Map;
+import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.tool.schema.internal.HibernateSchemaManagementTool;
 import org.hibernate.tool.schema.internal.exec.JdbcContext;
 import org.hibernate.tool.schema.spi.ExecutionOptions;
@@ -51,5 +54,16 @@ public class SpannerSchemaManagementTool extends HibernateSchemaManagementTool {
   SpannerTableExporter getSpannerTableExporter(ExecutionOptions options) {
     JdbcContext jdbcContext = this.resolveJdbcContext(options.getConfigurationValues());
     return (SpannerTableExporter) jdbcContext.getDialect().getTableExporter();
+  }
+
+  SpannerDatabaseInfo getDatabaseMetaData(ExecutionOptions options) {
+    JdbcContext jdbcContext = this.resolveJdbcContext(options.getConfigurationValues());
+    DdlTransactionIsolator ddlTransactionIsolator = this.getDdlTransactionIsolator(jdbcContext);
+    try {
+      DatabaseMetaData metaData = ddlTransactionIsolator.getIsolatedConnection().getMetaData();
+      return new SpannerDatabaseInfo(metaData);
+    } catch (SQLException e) {
+      throw new RuntimeException("Failed to get the Database metadata.", e);
+    }
   }
 }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaMigrator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaMigrator.java
@@ -48,7 +48,7 @@ public class SpannerSchemaMigrator implements SchemaMigrator {
     metadata.getDatabase().addAuxiliaryDatabaseObject(new StartBatchDdl(Action.UPDATE));
     metadata.getDatabase().addAuxiliaryDatabaseObject(new RunBatchDdl(Action.UPDATE));
 
-    tool.getSpannerTableExporter(options).initializeTableExporter(
+    tool.getSpannerTableExporter(options).init(
         metadata,
         tool.getDatabaseMetaData(options),
         Action.UPDATE);

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaMigrator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaMigrator.java
@@ -48,7 +48,10 @@ public class SpannerSchemaMigrator implements SchemaMigrator {
     metadata.getDatabase().addAuxiliaryDatabaseObject(new StartBatchDdl(Action.UPDATE));
     metadata.getDatabase().addAuxiliaryDatabaseObject(new RunBatchDdl(Action.UPDATE));
 
-    tool.getSpannerTableExporter(options).initializeTableExporter(metadata, Action.UPDATE);
+    tool.getSpannerTableExporter(options).initializeTableExporter(
+        metadata,
+        tool.getDatabaseMetaData(options),
+        Action.UPDATE);
 
     schemaMigrator.doMigration(metadata, options, targetDescriptor);
   }

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
@@ -27,6 +27,8 @@ import com.google.cloud.spanner.hibernate.entities.Employee;
 import com.google.cloud.spanner.hibernate.entities.GrandParent;
 import com.google.cloud.spanner.hibernate.entities.Parent;
 import com.mockrunner.mock.jdbc.JDBCMockObjectFactory;
+import com.mockrunner.mock.jdbc.MockConnection;
+import java.sql.SQLException;
 import java.util.List;
 import org.hibernate.Session;
 import org.hibernate.boot.Metadata;
@@ -40,17 +42,19 @@ public class GeneratedCreateTableStatementsTests {
 
   private StandardServiceRegistry registry;
 
-  private JDBCMockObjectFactory jdbcMockObjectFactory;
+  private MockConnection connection;
 
   /**
    * Set up the metadata for Hibernate to generate schema statements.
    */
   @Before
-  public void setup() {
-    this.jdbcMockObjectFactory = new JDBCMockObjectFactory();
-    this.jdbcMockObjectFactory.registerMockDriver();
-    this.jdbcMockObjectFactory.getMockDriver()
-        .setupConnection(this.jdbcMockObjectFactory.getMockConnection());
+  public void setup() throws SQLException {
+    JDBCMockObjectFactory jdbcMockObjectFactory = new JDBCMockObjectFactory();
+    jdbcMockObjectFactory.registerMockDriver();
+
+    this.connection = jdbcMockObjectFactory.getMockConnection();
+    this.connection.setMetaData(MockJdbcUtils.metaDataBuilder().build());
+    jdbcMockObjectFactory.getMockDriver().setupConnection(this.connection);
 
     this.registry = new StandardServiceRegistryBuilder()
         .applySetting("hibernate.dialect", SpannerDialect.class.getName())
@@ -64,7 +68,7 @@ public class GeneratedCreateTableStatementsTests {
   }
 
   @Test
-  public void testCreateDropInterleavedTables() {
+  public void testCreateInterleavedTables() throws SQLException {
     Metadata metadata =
         new MetadataSources(this.registry)
             .addAnnotatedClass(Child.class)
@@ -76,16 +80,11 @@ public class GeneratedCreateTableStatementsTests {
     session.beginTransaction();
     session.close();
 
-    List<String> sqlStrings = this.jdbcMockObjectFactory.getMockConnection()
-        .getStatementResultSetHandler()
-        .getExecutedStatements();
+    List<String> sqlStrings =
+        connection.getStatementResultSetHandler().getExecutedStatements();
 
     assertThat(sqlStrings).containsExactly(
         "START BATCH DDL",
-        "drop table Child",
-        "drop table Parent",
-        "drop table GrandParent",
-        "drop table hibernate_sequence",
         "RUN BATCH",
         "START BATCH DDL",
         "create table GrandParent (grandParentId INT64 not null,name STRING(255)) "
@@ -103,7 +102,7 @@ public class GeneratedCreateTableStatementsTests {
   }
 
   @Test
-  public void testUnsupportedExportersNoop() {
+  public void testCreateTables() throws SQLException {
     Metadata metadata =
         new MetadataSources(this.registry)
             .addAnnotatedClass(Employee.class)
@@ -113,15 +112,11 @@ public class GeneratedCreateTableStatementsTests {
     session.beginTransaction();
     session.close();
 
-    List<String> sqlStrings = this.jdbcMockObjectFactory.getMockConnection()
-        .getStatementResultSetHandler()
-        .getExecutedStatements();
+    List<String> sqlStrings =
+        this.connection.getStatementResultSetHandler().getExecutedStatements();
 
     assertThat(sqlStrings).containsExactly(
         "START BATCH DDL",
-        "drop index name_index",
-        "drop table Employee",
-        "drop table hibernate_sequence",
         "RUN BATCH",
         "START BATCH DDL",
         "create table Employee "
@@ -134,7 +129,35 @@ public class GeneratedCreateTableStatementsTests {
   }
 
   @Test
-  public void testCreateUniqueIndexes_uniqueColumn() {
+  public void testDropTables() throws SQLException {
+    Metadata metadata =
+        new MetadataSources(this.registry)
+            .addAnnotatedClass(Employee.class)
+            .buildMetadata();
+
+    this.connection.setMetaData(MockJdbcUtils.metaDataBuilder()
+        .setTables("Employee", "hibernate_sequence")
+        .setIndices("name_index")
+        .build());
+
+    Session session = metadata.buildSessionFactory().openSession();
+    session.beginTransaction();
+    session.close();
+
+    List<String> sqlStrings =
+        this.connection.getStatementResultSetHandler().getExecutedStatements();
+
+    assertThat(sqlStrings).startsWith(
+        "START BATCH DDL",
+        "drop index name_index",
+        "drop table Employee",
+        "drop table hibernate_sequence",
+        "RUN BATCH"
+    );
+  }
+
+  @Test
+  public void testCreateUniqueIndexes_uniqueColumn() throws SQLException {
     Metadata metadata =
         new MetadataSources(this.registry)
             .addAnnotatedClass(Airplane.class)
@@ -144,14 +167,11 @@ public class GeneratedCreateTableStatementsTests {
     session.beginTransaction();
     session.close();
 
-    List<String> sqlStrings = this.jdbcMockObjectFactory.getMockConnection()
-        .getStatementResultSetHandler()
-        .getExecutedStatements();
+    List<String> sqlStrings =
+        this.connection.getStatementResultSetHandler().getExecutedStatements();
 
     assertThat(sqlStrings).containsExactly(
         "START BATCH DDL",
-        "drop index UK_gc568wb30sampsuirwne5jqgh",
-        "drop table Airplane",
         "RUN BATCH",
         "START BATCH DDL",
         "create table Airplane (id STRING(255) not null,modelName STRING(255)) PRIMARY KEY (id)",
@@ -161,7 +181,7 @@ public class GeneratedCreateTableStatementsTests {
   }
 
   @Test
-  public void testCreateUniqueIndexes_oneToMany() {
+  public void testCreateUniqueIndexes_oneToMany() throws SQLException {
     Metadata metadata =
         new MetadataSources(this.registry)
             .addAnnotatedClass(Airport.class)
@@ -172,20 +192,14 @@ public class GeneratedCreateTableStatementsTests {
     session.beginTransaction();
     session.close();
 
-    List<String> sqlStrings = this.jdbcMockObjectFactory.getMockConnection()
-        .getStatementResultSetHandler()
-        .getExecutedStatements();
+    List<String> sqlStrings =
+        this.connection.getStatementResultSetHandler().getExecutedStatements();
 
     // Note that Hibernate generates a unique column for @OneToMany relationships because
     // one object is mapped to many others; this is distinct from the @ManyToMany case.
     // See: https://hibernate.atlassian.net/browse/HHH-3410
     assertThat(sqlStrings).containsExactly(
         "START BATCH DDL",
-        "drop index UK_gc568wb30sampsuirwne5jqgh",
-        "drop table Airplane",
-        "drop table Airport",
-        "drop index UK_em0lqvwoqdwt29x0b0r010be",
-        "drop table Airport_Airplane",
         "RUN BATCH",
         "START BATCH DDL",
         "create table Airplane (id STRING(255) not null,modelName STRING(255)) PRIMARY KEY (id)",

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedSelectStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedSelectStatementsTests.java
@@ -24,7 +24,9 @@ import com.google.cloud.spanner.hibernate.entities.SubTestEntity;
 import com.google.cloud.spanner.hibernate.entities.TestEntity;
 import com.google.cloud.spanner.hibernate.entities.TestEntity.IdClass;
 import com.mockrunner.mock.jdbc.JDBCMockObjectFactory;
+import com.mockrunner.mock.jdbc.MockConnection;
 import com.mockrunner.mock.jdbc.MockPreparedStatement;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -57,11 +59,14 @@ public class GeneratedSelectStatementsTests {
    * Set up the metadata for Hibernate to generate schema statements.
    */
   @Before
-  public void setup() {
+  public void setup() throws SQLException {
     this.jdbcMockObjectFactory = new JDBCMockObjectFactory();
     this.jdbcMockObjectFactory.registerMockDriver();
+
+    MockConnection connection = this.jdbcMockObjectFactory.getMockConnection();
+    connection.setMetaData(MockJdbcUtils.metaDataBuilder().build());
     this.jdbcMockObjectFactory.getMockDriver()
-        .setupConnection(this.jdbcMockObjectFactory.getMockConnection());
+        .setupConnection(connection);
 
     this.registry = new StandardServiceRegistryBuilder()
         .applySetting("hibernate.dialect", SpannerDialect.class.getName())
@@ -72,6 +77,7 @@ public class GeneratedSelectStatementsTests {
         .applySetting("hibernate.connection.password", "unused")
         .applySetting("hibernate.hbm2ddl.auto", "create")
         .build();
+
     this.metadata =
         new MetadataSources(this.registry).addAnnotatedClass(TestEntity.class)
             .addAnnotatedClass(SubTestEntity.class).buildMetadata();

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedUpdateTableStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedUpdateTableStatementsTests.java
@@ -103,7 +103,7 @@ public class GeneratedUpdateTableStatementsTests {
    * Sets up which pre-existing tables that Hibernate sees.
    */
   private void setupTestTables(String... tables) throws SQLException {
-    mockConnection.setMetaData(MockJdbcUtils.createMockDatabaseMetaData(tables));
+    mockConnection.setMetaData(MockJdbcUtils.metaDataBuilder().setTables(tables).build());
 
     Metadata metadata =
         new MetadataSources(this.registry)

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
@@ -138,6 +138,7 @@ public class SpannerTableExporterTests {
     List<String> statements = Files.readAllLines(scriptFile.toPath());
 
     assertThat(statements).containsExactly(
+        // This omits creating the Employee table since it is declared to exist in metadata.
         "START BATCH DDL",
         "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
         "INSERT INTO hibernate_sequence (next_val) VALUES(1)",


### PR DESCRIPTION
This checks the existence of tables and indices before attempting to create or delete them in Spanner. This is necessary since dropping an nonexistent table or creating a table with a duplicate name will both result in error.

Fixes #176.