### PR TITLE
Defer hibernate sequence DML to after DDL batch

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/RunBatchDdl.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/RunBatchDdl.java
@@ -46,7 +46,8 @@ public class RunBatchDdl implements AuxiliaryDatabaseObject {
   }
 
   /**
-   * Add a statement to run after the DDL batch is completed.
+   * Add a statement to run after the DDL batch is completed. This is useful for executing
+   * additional DML statements since these cannot be run in a DDL batch.
    */
   public void addAfterDdlStatement(String statement) {
     statements.add(statement);

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/RunBatchDdl.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/RunBatchDdl.java
@@ -19,6 +19,8 @@
 package com.google.cloud.spanner.hibernate.schema;
 
 import com.google.cloud.spanner.hibernate.SpannerDialect;
+import java.util.ArrayList;
+import java.util.List;
 import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.tool.schema.Action;
@@ -31,8 +33,23 @@ public class RunBatchDdl implements AuxiliaryDatabaseObject {
 
   private final Action schemaAction;
 
+  private final List<String> statements;
+
+  /**
+   * Constructs the {@link RunBatchDdl} auxiliary database object.
+   * @param schemaAction the DDL mode being used for schema generation.
+   */
   public RunBatchDdl(Action schemaAction) {
     this.schemaAction = schemaAction;
+    this.statements = new ArrayList<>();
+    this.statements.add("RUN BATCH");
+  }
+
+  /**
+   * Add a statement to run after the DDL batch is completed.
+   */
+  public void addAfterDdlStatement(String statement) {
+    statements.add(statement);
   }
 
   @Override
@@ -52,7 +69,7 @@ public class RunBatchDdl implements AuxiliaryDatabaseObject {
 
   @Override
   public String[] sqlCreateStrings(Dialect dialect) {
-    return new String[] {"RUN BATCH"};
+    return statements.toArray(new String[statements.size()]);
   }
 
   @Override
@@ -60,7 +77,7 @@ public class RunBatchDdl implements AuxiliaryDatabaseObject {
     if (schemaAction == Action.UPDATE) {
       return new String[]{};
     } else {
-      return new String[]{"RUN BATCH"};
+      return statements.toArray(new String[statements.size()]);
     }
   }
 }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerTableStatements.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerTableStatements.java
@@ -163,11 +163,13 @@ public class SpannerTableStatements {
     statements.add(createTableString);
 
     if (table.getName().equals(SequenceStyleGenerator.DEF_SEQUENCE_NAME)) {
-      // Caches the INSERT statement for after the DDL batch.
+      // Caches the INSERT statement since DML statements must be run after a DDL batch.
       addStatementAfterDdlBatch(
           metadata,
-          "INSERT INTO " + SequenceStyleGenerator.DEF_SEQUENCE_NAME + " ("
-              + SequenceStyleGenerator.DEF_VALUE_COLUMN + ") VALUES(1)");
+          String.format(
+              "INSERT INTO %s (%s) VALUES(1)",
+              SequenceStyleGenerator.DEF_SEQUENCE_NAME,
+              SequenceStyleGenerator.DEF_VALUE_COLUMN));
     }
 
     return statements;

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerTableStatements.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerTableStatements.java
@@ -166,10 +166,8 @@ public class SpannerTableStatements {
       // Caches the INSERT statement since DML statements must be run after a DDL batch.
       addStatementAfterDdlBatch(
           metadata,
-          String.format(
-              "INSERT INTO %s (%s) VALUES(1)",
-              SequenceStyleGenerator.DEF_SEQUENCE_NAME,
-              SequenceStyleGenerator.DEF_VALUE_COLUMN));
+          "INSERT INTO " + SequenceStyleGenerator.DEF_SEQUENCE_NAME + " ("
+              + SequenceStyleGenerator.DEF_VALUE_COLUMN + ") VALUES(1)");
     }
 
     return statements;

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerTableStatements.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerTableStatements.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -36,11 +37,14 @@ import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Index;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.UniqueKey;
+import org.jboss.logging.Logger;
 
 /**
  * Generates the SQL statements for creating and dropping tables in Spanner.
  */
 public class SpannerTableStatements {
+
+  private static final Logger LOGGER = Logger.getLogger(SpannerTableStatements.class);
 
   private static final String CREATE_TABLE_TEMPLATE =
       "create table {0} ({1}) PRIMARY KEY ({2}){3}";
@@ -158,10 +162,22 @@ public class SpannerTableStatements {
 
     statements.add(createTableString);
 
-    // Hibernate requires the special hibernate_sequence table to be populated with an initial val.
     if (table.getName().equals(SequenceStyleGenerator.DEF_SEQUENCE_NAME)) {
-      statements.add("INSERT INTO " + SequenceStyleGenerator.DEF_SEQUENCE_NAME + " ("
-          + SequenceStyleGenerator.DEF_VALUE_COLUMN + ") VALUES(1)");
+      // Caches the INSERT statement in the RunBatchDdl auxiliary object.
+      Optional<RunBatchDdl> runBatchDdl =
+          metadata.getDatabase().getAuxiliaryDatabaseObjects().stream()
+              .filter(obj -> obj instanceof RunBatchDdl)
+              .map(obj -> (RunBatchDdl) obj)
+              .findFirst();
+
+      if (runBatchDdl.isPresent()) {
+        RunBatchDdl runBatchObj = runBatchDdl.get();
+        runBatchObj.addAfterDdlStatement(
+            "INSERT INTO " + SequenceStyleGenerator.DEF_SEQUENCE_NAME + " ("
+                + SequenceStyleGenerator.DEF_VALUE_COLUMN + ") VALUES(1)");
+      } else {
+        LOGGER.warn("Failed to insert the first row into the Hibernate sequence table.");
+      }
     }
 
     return statements;

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
@@ -68,7 +68,7 @@ public class GeneratedCreateTableStatementsTests {
   }
 
   @Test
-  public void testCreateInterleavedTables() throws SQLException {
+  public void testCreateInterleavedTables() {
     Metadata metadata =
         new MetadataSources(this.registry)
             .addAnnotatedClass(Child.class)
@@ -97,12 +97,13 @@ public class GeneratedCreateTableStatementsTests {
             + "PRIMARY KEY (grandParentId,parentId,childId), "
             + "INTERLEAVE IN PARENT Parent",
         "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
-        "INSERT INTO hibernate_sequence (next_val) VALUES(1)",
-        "RUN BATCH");
+        "RUN BATCH",
+        "INSERT INTO hibernate_sequence (next_val) VALUES(1)"
+    );
   }
 
   @Test
-  public void testCreateTables() throws SQLException {
+  public void testCreateTables() {
     Metadata metadata =
         new MetadataSources(this.registry)
             .addAnnotatedClass(Employee.class)
@@ -122,9 +123,9 @@ public class GeneratedCreateTableStatementsTests {
         "create table Employee "
             + "(id INT64 not null,name STRING(255),manager_id INT64) PRIMARY KEY (id)",
         "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
-        "INSERT INTO hibernate_sequence (next_val) VALUES(1)",
         "create index name_index on Employee (name)",
-        "RUN BATCH"
+        "RUN BATCH",
+        "INSERT INTO hibernate_sequence (next_val) VALUES(1)"
     );
   }
 

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedUpdateTableStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedUpdateTableStatementsTests.java
@@ -76,9 +76,9 @@ public class GeneratedUpdateTableStatementsTests {
         "create table Employee (id INT64 not null,name STRING(255),manager_id INT64) "
             + "PRIMARY KEY (id)",
         "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
-        "INSERT INTO hibernate_sequence (next_val) VALUES(1)",
         "create index name_index on Employee (name)",
-        "RUN BATCH"
+        "RUN BATCH",
+        "INSERT INTO hibernate_sequence (next_val) VALUES(1)"
     );
   }
 
@@ -93,9 +93,9 @@ public class GeneratedUpdateTableStatementsTests {
         "alter table Employee ADD COLUMN name STRING(255)",
         "alter table Employee ADD COLUMN manager_id INT64",
         "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
-        "INSERT INTO hibernate_sequence (next_val) VALUES(1)",
         "create index name_index on Employee (name)",
-        "RUN BATCH"
+        "RUN BATCH",
+        "INSERT INTO hibernate_sequence (next_val) VALUES(1)"
     );
   }
 

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
@@ -141,9 +141,10 @@ public class SpannerTableExporterTests {
         // This omits creating the Employee table since it is declared to exist in metadata.
         "START BATCH DDL",
         "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
-        "INSERT INTO hibernate_sequence (next_val) VALUES(1)",
         "create index name_index on Employee (name)",
-        "RUN BATCH");
+        "RUN BATCH",
+        "INSERT INTO hibernate_sequence (next_val) VALUES(1)"
+    );
   }
 
 


### PR DESCRIPTION
This PR modifies the `INSERT` statement used for creating the hibernate_sequence table by deferring it until after the DDL batch is complete.

Fixes #171 