### PR TITLE
Add version fields to manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
`addDefaultImplementationEntries` field of the jar plugin adds the following three fields:

```
Implementation-Title: Google Cloud Spanner Dialect for Hibernate ORM
Implementation-Version: 1.2.0-SNAPSHOT
Implementation-Vendor: Google LLC
```

Fixes #187 