### PR TITLE
Bump snapshot versions from 1.2.0 to 1.3.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ Maven coordinates for the dialect:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-hibernate-dialect</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
 </dependency>
 ----
 

--- a/google-cloud-spanner-hibernate-dialect/pom.xml
+++ b/google-cloud-spanner-hibernate-dialect/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/google-cloud-spanner-hibernate-performance-testing/pom.xml
+++ b/google-cloud-spanner-hibernate-performance-testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>google-cloud-spanner-hibernate</artifactId>
 		<groupId>com.google.cloud</groupId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/google-cloud-spanner-hibernate-samples/quarkus-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/quarkus-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-testing/pom.xml
+++ b/google-cloud-spanner-hibernate-testing/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>google-cloud-spanner-hibernate</artifactId>
 		<groupId>com.google.cloud</groupId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-hibernate</artifactId>
   <packaging>pom</packaging>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
I completed the release process for version 1.2.0 and am incrementing version numbers to 1.3.0.

- 1.2.0 released on Maven: https://search.maven.org/artifact/com.google.cloud/google-cloud-spanner-hibernate
- 1.2.0 Github Release created: https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate/releases
- Hibernate sample version has been updated to 1.2: https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/spanner/hibernate/pom.xml#L33
- codelab updated: https://codelabs.developers.google.com/codelabs/cloud-spanner-hibernate/#4