### PR TITLE
Bump snapshot version from 1.3.0 to 1.4.0 after release

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ Maven coordinates for the dialect:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-hibernate-dialect</artifactId>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
 </dependency>
 ----
 
@@ -76,7 +76,7 @@ In these cases, it is recommended to add the dialect dependency in a separate bu
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner-hibernate-dialect</artifactId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
       </dependency>
     </dependencies>
   </profile>

--- a/google-cloud-spanner-hibernate-dialect/pom.xml
+++ b/google-cloud-spanner-hibernate-dialect/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/google-cloud-spanner-hibernate-performance-testing/pom.xml
+++ b/google-cloud-spanner-hibernate-performance-testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>google-cloud-spanner-hibernate</artifactId>
 		<groupId>com.google.cloud</groupId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.4.0-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/google-cloud-spanner-hibernate-samples/quarkus-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/quarkus-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-testing/pom.xml
+++ b/google-cloud-spanner-hibernate-testing/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>google-cloud-spanner-hibernate</artifactId>
 		<groupId>com.google.cloud</groupId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.4.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-hibernate</artifactId>
   <packaging>pom</packaging>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
I released a new version of the hibernate dialect to accomodate the `NUMERIC` support.

Notes:
* Version 1.3.0 appearing in maven central: https://repo.maven.apache.org/maven2/com/google/cloud/google-cloud-spanner-hibernate-dialect/
* Codelab updated + republished: https://docs.google.com/document/d/1bcAKgl1vv86jxtcNZb0FkgFt3S_WKh2CAS5ottGQREY/edit#
* Release created:  https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate/releases/tag/1.3.0
* Hibernate Sample: The versions for the java-samples get automatically upgraded by a bot