### PR TITLE
fix: do not add services if Spanner dialect is not used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ target
 *.iml
 .idea
 
+# eclipse
+.project
+.settings
+.classpath
+
 # Ignores generated files through testing
 **/transaction.log
 

--- a/README.adoc
+++ b/README.adoc
@@ -61,34 +61,6 @@ The driver will use default credentials set in the Google Cloud SDK `gcloud` app
 
 You are now ready to begin using Hibernate with Cloud Spanner.
 
-=== Multi-Database Support
-
-In some cases, you will want to connect to multiple databases in the same project (for example connecting to Cloud Spanner for production and H2 for testing).
-
-At the present moment, it is not possible to connect to another non-Spanner database through Hibernate if the Spanner dialect (`google-cloud-spanner-hibernate-dialect`) is on the project classpath.
-
-In these cases, it is recommended to add the dialect dependency in a separate build profile to accommodate connecting to other databases. For example, in Maven, you might add a separate maven profile like this:
-
-[source, xml]
-----
-
-<profiles>
-  <profile>
-    <id>spanner</id>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-spanner-hibernate-dialect</artifactId>
-        <version>1.3.0</version>
-      </dependency>
-    </dependencies>
-  </profile>
-    ...
-</profiles>
-----
-
-You can then activate the profile using `-Pspanner` such as `mvn compile -Pspanner`.
-
 == User Guide
 
 This guide contains a variety of best practices for using Hibernate with Spanner which can significantly improve the performance of your application.

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerServiceContributor.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerServiceContributor.java
@@ -20,6 +20,7 @@ package com.google.cloud.spanner.hibernate;
 
 import com.google.cloud.spanner.hibernate.schema.SpannerSchemaManagementTool;
 import java.util.Map;
+import java.util.Objects;
 import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.hql.spi.id.inline.InlineIdsOrClauseBulkIdStrategy;
@@ -47,27 +48,31 @@ public class SpannerServiceContributor implements ServiceContributor {
 
   @Override
   public void contribute(StandardServiceRegistryBuilder serviceRegistryBuilder) {
-    serviceRegistryBuilder
-        // The custom Hibernate schema management tool for Spanner.
-        .addInitiator(new StandardServiceInitiator() {
-          @Override
-          public Service initiateService(Map configurationValues,
-              ServiceRegistryImplementor registry) {
-            return SCHEMA_MANAGEMENT_TOOL;
-          }
-
-          @Override
-          public Class getServiceInitiated() {
-            return SchemaManagementTool.class;
-          }
-        })
-        // The user agent JDBC connection property to identify the library.
-        .applySetting("hibernate.connection.userAgent", HIBERNATE_API_CLIENT_LIB_TOKEN)
-        // Create a unique index for a table if it does not already exist when in UPDATE mode.
-        .applySetting(
-            "hibernate.schema_update.unique_constraint_strategy",
-            UniqueConstraintSchemaUpdateStrategy.RECREATE_QUIETLY)
-        // Allows entities to be used with InheritanceType.JOINED in Spanner.
-        .applySetting("hibernate.hql.bulk_id_strategy", InlineIdsOrClauseBulkIdStrategy.INSTANCE);
+    if (Objects.equals(
+        serviceRegistryBuilder.getSettings().get("hibernate.dialect"),
+        SpannerDialect.class.getName())) {
+      serviceRegistryBuilder
+          // The custom Hibernate schema management tool for Spanner.
+          .addInitiator(new StandardServiceInitiator() {
+            @Override
+            public Service initiateService(Map configurationValues,
+                ServiceRegistryImplementor registry) {
+              return SCHEMA_MANAGEMENT_TOOL;
+            }
+  
+            @Override
+            public Class getServiceInitiated() {
+              return SchemaManagementTool.class;
+            }
+          })
+          // The user agent JDBC connection property to identify the library.
+          .applySetting("hibernate.connection.userAgent", HIBERNATE_API_CLIENT_LIB_TOKEN)
+          // Create a unique index for a table if it does not already exist when in UPDATE mode.
+          .applySetting(
+              "hibernate.schema_update.unique_constraint_strategy",
+              UniqueConstraintSchemaUpdateStrategy.RECREATE_QUIETLY)
+          // Allows entities to be used with InheritanceType.JOINED in Spanner.
+          .applySetting("hibernate.hql.bulk_id_strategy", InlineIdsOrClauseBulkIdStrategy.INSTANCE);
+    }
   }
 }


### PR DESCRIPTION
The Spanner dialect would add services and configuration, even if the Spanner dialect was not used, but was present on the classpath. This makes it impossible to develop an application that can run on both Cloud Spanner and other databases,
as the Spanner services would be loaded and used for all databases.

It also made it impossible to use for example H2 for testing purposes, while using Cloud Spanner for production.

This PR also contains a change for the `SpannerServiceContributorTest`, as that test would not work on Java 11. This version should work on both Java 8 and Java 11.