### PR TITLE
Bump versions for 1.4.0 release

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ Maven coordinates for the dialect:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-hibernate-dialect</artifactId>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
 </dependency>
 ----
 

--- a/google-cloud-spanner-hibernate-dialect/pom.xml
+++ b/google-cloud-spanner-hibernate-dialect/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/google-cloud-spanner-hibernate-performance-testing/pom.xml
+++ b/google-cloud-spanner-hibernate-performance-testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>google-cloud-spanner-hibernate</artifactId>
 		<groupId>com.google.cloud</groupId>
-		<version>1.4.0-SNAPSHOT</version>
+		<version>1.5.0-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/google-cloud-spanner-hibernate-samples/quarkus-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/quarkus-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-testing/pom.xml
+++ b/google-cloud-spanner-hibernate-testing/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>google-cloud-spanner-hibernate</artifactId>
 		<groupId>com.google.cloud</groupId>
-		<version>1.4.0-SNAPSHOT</version>
+		<version>1.5.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-hibernate</artifactId>
   <packaging>pom</packaging>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.5.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Bump the version numbers for the 1.4.0 release.

* Maven Central: https://repo.maven.apache.org/maven2/com/google/cloud/google-cloud-spanner-hibernate-dialect/
* Codelab versions: https://codelabs.developers.google.com/codelabs/cloud-spanner-hibernate/#4
* Github Release: https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate/releases/tag/1.4.0