### PR TITLE
fix: close session and sessionFactory when finished

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ target
 
 # local libs
 /libs
+
+# eclipse
+.project
+.settings
+.classpath

--- a/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/src/main/java/com/example/SampleApplication.java
+++ b/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/src/main/java/com/example/SampleApplication.java
@@ -53,12 +53,18 @@ public class SampleApplication {
     SessionFactory sessionFactory = new MetadataSources(registry).buildMetadata()
         .buildSessionFactory();
     Session session = sessionFactory.openSession();
-
-    // Save a Person entity into Spanner Table.
-    savePerson(session);
-
-    // Save a singer entity into the Spanner Table.
-    saveSingerAlbum(session);
+  
+    try {
+      // Save a Person entity into Spanner Table.
+      savePerson(session);
+  
+      // Save a singer entity into the Spanner Table.
+      saveSingerAlbum(session);
+      
+    } finally {
+      session.close();
+      sessionFactory.close();
+    }
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,14 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.8.2</version>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>3.0.0</version>
+          <configuration>
+            <cleanupDaemonThreads>false</cleanupDaemonThreads>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@
           <artifactId>exec-maven-plugin</artifactId>
           <version>3.0.0</version>
           <configuration>
+            <!-- Turns off the cleanup of daemon threads to avoid spurious error messages. #218 -->
             <cleanupDaemonThreads>false</cleanupDaemonThreads>
           </configuration>
         </plugin>


### PR DESCRIPTION
The sample application should close the session and session factory when the application finishes. Failing to do so, will keep at least one JDBC connection open, which again could cause sessions to be kept around on the backend until they are garbage collected one hour later.

This chanage also turns off the cleanup of daemon threads by the maven-exec plugin. Otherwise it reports a large number of false positives of threads that are supposedly not shutdown. They are however closed by a shutdown hook after the check has been executed (the check is executed by this method: https://github.com/mojohaus/exec-maven-plugin/blob/d0e13ba1ddd383bc461f0efe547c91166ad789bf/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java#L300)
