### PR TITLE
Split up unit tests from integration tests

### DIFF
--- a/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/src/test/java/com/example/SampleApplicationIT.java
+++ b/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/src/test/java/com/example/SampleApplicationIT.java
@@ -41,7 +41,7 @@ import org.junit.Test;
  * @author Chengyuan Zhao
  * @author Daniel Zou
  */
-public class SampleApplicationTests {
+public class SampleApplicationIT {
 
   private final StandardServiceRegistry registry =
       new StandardServiceRegistryBuilder()

--- a/google-cloud-spanner-hibernate-samples/basic-spanner-features-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/basic-spanner-features-sample/pom.xml
@@ -9,6 +9,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
+  <name>Google Cloud Spanner Hibernate Basic Features Sample</name>
   <artifactId>basic-spanner-features-sample</artifactId>
 
   <dependencies>

--- a/google-cloud-spanner-hibernate-samples/quarkus-jpa-sample/src/test/java/com/example/PersonApplicationIT.java
+++ b/google-cloud-spanner-hibernate-samples/quarkus-jpa-sample/src/test/java/com/example/PersonApplicationIT.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-public class PersonApplicationTest {
+public class PersonApplicationIT {
 
   @Test
   public void testPersonEndpoint() {

--- a/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/pom.xml
@@ -9,6 +9,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
+  <name>Google Cloud Spanner Hibernate Codelab</name>
   <artifactId>spanner-hibernate-codelab</artifactId>
   <description>Source code for the Cloud Spanner with Hibernate ORM Codelab</description>
 

--- a/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/src/test/java/codelab/AppIT.java
+++ b/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/src/test/java/codelab/AppIT.java
@@ -27,7 +27,7 @@ import org.junit.contrib.java.lang.system.SystemOutRule;
 /**
  * This verifies the sample application.
  */
-public class AppTests {
+public class AppIT {
 
   @Rule
   public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
@@ -12,12 +12,16 @@
   <name>Google Cloud Spanner Hibernate with Spring Data JPA Sample</name>
   <artifactId>spring-data-jpa-sample</artifactId>
 
+  <properties>
+      <spring-boot-version>2.2.0.RELEASE</spring-boot-version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.2.0.RELEASE</version>
+        <version>${spring-boot-version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -69,6 +73,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/src/test/java/com/example/CoffeeApplicationIT.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/src/test/java/com/example/CoffeeApplicationIT.java
@@ -44,7 +44,7 @@ import org.springframework.util.LinkedMultiValueMap;
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = CoffeeApplication.class)
 @TestPropertySource("classpath:application-test.properties")
-public class CoffeeApplicationTests {
+public class CoffeeApplicationIT {
 
   @Autowired
   CustomerRepository customerRepository;

--- a/google-cloud-spanner-hibernate-testing/pom.xml
+++ b/google-cloud-spanner-hibernate-testing/pom.xml
@@ -73,6 +73,24 @@
 	<build>
 		<plugins>
 			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${maven-surefire-plugin.version}</version>
+				<configuration>
+					<skipTests>true</skipTests>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>${maven-failsafe-plugin.version}</version>
+				<configuration>
+					<includes>
+						<include>**/*Tests.java</include>
+						<include>**/*Test.java</include>
+						<include>**/*TestCase.java</include>
+					</includes>
+				</configuration>
+			</plugin>
+			<plugin>
 				<artifactId>maven-deploy-plugin</artifactId>
 				<configuration>
 					<skip>true</skip>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,9 @@
     <hibernate.version>5.4.9.Final</hibernate.version>
     <spanner-jdbc-driver.version>1.18.3</spanner-jdbc-driver.version>
     <log4j.version>2.13.3</log4j.version>
+
+    <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>${maven-surefire-plugin.version}</maven-failsafe-plugin.version>
   </properties>
 
   <name>Google Cloud Spanner Dialect for Hibernate ORM Parent</name>
@@ -196,13 +199,19 @@
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <includes>
             <include>**/*Tests.java</include>
             <include>**/*Test.java</include>
           </includes>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven-failsafe-plugin.version}</version>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
1. Renames some of the sample integration tests from `*Test[s]` --> `*IT` (matches Maven failsafe default).
2. Per our team chat, disables unit tests in the `google-cloud-spanner-hibernate-testing` because there ~140 classes that end in `Test` or `Tests` or `TestCase` that would need to be renamed. 
3. Fixes some build warnings/errors (there's still a Mockito error because it's usually a *really* old version of Mockito (from Dec 31, 2014)
4. Adds some naming consistency to modules