### PR TITLE
Use JDK 11 in CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 
 dist: trusty
 


### PR DESCRIPTION
Sonar is rejecting builds from JDK8