### PR TITLE
Delete the `disable-integration-test` profile

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -20,7 +20,7 @@ set -eo pipefail
 dir=$(dirname "$0")
 
 pushd $dir/../
-./mvnw verify -B -V -P disable-integration-tests
+./mvnw install -B -V -DskipTests
 popd
 
 source $dir/release_snapshot.sh

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -20,7 +20,7 @@ set -eo pipefail
 dir=$(dirname "$0")
 
 pushd $dir/../
-./mvnw install -B -V -DskipTests
+./mvnw install -B -V -DskipITs
 popd
 
 source $dir/release_snapshot.sh

--- a/.kokoro/stage.sh
+++ b/.kokoro/stage.sh
@@ -28,8 +28,8 @@ MAVEN_SETTINGS_FILE=$(realpath .)/settings.xml
 setup_environment_secrets
 create_settings_xml_file $MAVEN_SETTINGS_FILE
 
-# run unit tests
-./mvnw install -B -V
+# install and run unit tests
+./mvnw install -B -V -DskipITs
 
 # change to release version
 ./mvnw versions:set -DremoveSnapshot

--- a/.kokoro/stage.sh
+++ b/.kokoro/stage.sh
@@ -29,7 +29,7 @@ setup_environment_secrets
 create_settings_xml_file $MAVEN_SETTINGS_FILE
 
 # run unit tests
-./mvnw verify -B -V -P disable-integration-tests
+./mvnw install -B -V
 
 # change to release version
 ./mvnw versions:set -DremoveSnapshot

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
       secure: "bJbPI9/edK+++PK1PsJNF6xApzhQbkeIB0587P6IVTjmIS/+yh/RcBHAkRN4q2TGKKeItyjyps/N1pz3jDidmvxDYlJhoPJDpcbYA50Gicw1xsjyf172bJ7BNl09wYNYUpHFVk5mTJtVKtkePwICMXkiftLMrJhuTbunNnXovrQuA6mb1gI3lNm2NC9bQEsm1arUAmYFVCLdeeAU7JD039e0qTMMtdREBd0idzWoQHd5b0Te2HJ6jE4AvuiGnygdPUiCceS5s6Ytfi0K/KCIUTlujW3Cmcn1Of4GkSpKx31ScMwRZCOHgZo5dKEIgsPiVOF8XiNgTugBjf+k+f/qxmFa/koe1Yb2p7whzCkykBt6jcEnm/lZ2m3eysO6gvDlRRFNHj7epYwCt298x4GUNZ9dNYXGhRgqdmJCp0G/MpovnZwpayfJmXd9QgE7pGm/Xf8IGLxQwWKSEtqLdfAq6hyDmENLHxBfCzA3EYXpfSNcszfk1zhky1nexnV0hsmAqUHQHIdRNkCOvl2T6rmYj8xCGcYa09ROG/bEnfqJt2nEEIPSBhWyGgisAkG0BqLX/aufb4Uzpge34Lg65477c1d8jgz/hw/xV2b/OV4Exn6C34MHeRBhPr0Q4xHd1sw3w8mOJvdkSKrXvdz9F0U2qb3jDennKrI6J38RgUs0D/8="
 
 install:
-  - ./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -P disable-integration-tests;
+  - ./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 before_install:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
@@ -35,6 +35,6 @@ script:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
       ./mvnw org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar -B -V -Dsonar.projectKey=google-cloud-spanner-hibernate -Dhibernate.show_sql=false;
     else
-      ./mvnw verify -B -V -P disable-integration-tests;
+      ./mvnw test -B -V
     fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,6 @@ script:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
       ./mvnw org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar -B -V -Dsonar.projectKey=google-cloud-spanner-hibernate -Dhibernate.show_sql=false;
     else
-      ./mvnw test -B -V
+      ./mvnw test -B -V;
     fi;
 

--- a/google-cloud-spanner-hibernate-samples/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/pom.xml
@@ -14,15 +14,6 @@
 	<artifactId>google-cloud-spanner-hibernate-samples</artifactId>
 	<packaging>pom</packaging>
 
-	<profiles>
-		<profile>
-			<id>disable-integration-tests</id>
-			<properties>
-				<maven.test.skip>true</maven.test.skip>
-			</properties>
-		</profile>
-	</profiles>
-
 	<modules>
 		<module>basic-hibernate-sample</module>
 		<module>spring-data-jpa-sample</module>

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
@@ -79,12 +79,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <useModulePath>false</useModulePath>
-          <additionalClasspathElements>
-            <additionalClasspathElement>${basedir}/target/classes</additionalClasspathElement>
-          </additionalClasspathElements>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
@@ -13,7 +13,7 @@
   <artifactId>spring-data-jpa-sample</artifactId>
 
   <properties>
-      <spring-boot-version>2.2.0.RELEASE</spring-boot-version>
+      <spring-boot-version>2.3.9.RELEASE</spring-boot-version>
   </properties>
 
   <dependencyManagement>
@@ -74,6 +74,17 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>${spring-boot-version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <useModulePath>false</useModulePath>
+          <additionalClasspathElements>
+            <additionalClasspathElement>${basedir}/target/classes</additionalClasspathElement>
+          </additionalClasspathElements>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
@@ -75,11 +75,6 @@
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>${spring-boot-version}</version>
       </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 

--- a/google-cloud-spanner-hibernate-testing/pom.xml
+++ b/google-cloud-spanner-hibernate-testing/pom.xml
@@ -58,17 +58,7 @@
 			<artifactId>ehcache</artifactId>
 			<version>3.7.0</version>
 		</dependency>
-
 	</dependencies>
-
-	<profiles>
-		<profile>
-			<id>disable-integration-tests</id>
-			<properties>
-				<maven.test.skip>true</maven.test.skip>
-			</properties>
-		</profile>
-	</profiles>
 
 	<build>
 		<plugins>

--- a/google-cloud-spanner-hibernate-testing/src/test/resources/hibernate.properties
+++ b/google-cloud-spanner-hibernate-testing/src/test/resources/hibernate.properties
@@ -10,7 +10,6 @@
 hibernate.dialect com.google.cloud.spanner.hibernate.SpannerDialect
 hibernate.connection.driver_class com.google.cloud.spanner.jdbc.JdbcDriver
 hibernate.connection.url jdbc:cloudspanner:/projects/cloud-spanner-hibernate-ci/instances/test-instance/databases/test-database
-hibernate.hql.bulk_id_strategy=org.hibernate.jpa.test.ParallelInlineIdsOrClauseBulkIdStrategy
 
 hibernate.show_sql=true
 hibernate.connection.pool_size 5

--- a/google-cloud-spanner-hibernate-testing/src/test/resources/hibernate.properties
+++ b/google-cloud-spanner-hibernate-testing/src/test/resources/hibernate.properties
@@ -20,6 +20,4 @@ hibernate.max_fetch_depth 5
 hibernate.cache.region_prefix hibernate.test
 hibernate.cache.region.factory_class org.hibernate.testing.cache.CachingRegionFactory
 
-hibernate.jdbc.batch_size 0
-
-hibernate.service.allow_crawling=false
+hibernate.jdbc.batch_size 100

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,15 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>${maven-failsafe-plugin.version}</version>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,13 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>${maven-failsafe-plugin.version}</version>
 
+        <configuration>
+          <useModulePath>false</useModulePath>
+          <additionalClasspathElements>
+            <additionalClasspathElement>${basedir}/target/classes</additionalClasspathElement>
+          </additionalClasspathElements>
+        </configuration>
+
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
This removes the `disable-integration-test` profile, which should no longer be used after migrating to the fail-safe plugin which separates unit tests from integration tests. This profile was used to disable integration tests from being run by the surefire plugin back before I knew about differences between surefire vs. failsafe.