### PR TITLE
ci: dependabot to ignore Quarkus 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  ignored_updates:
+  - match:
+      dependency_name: "io.quarkus:quarkus-universe-bom"
+      # Quarkus 2 requires Java 11, which is too high.
+      version_requirement: ">=2.0.0.Final"


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate/issues/294