### PR TITLE
Make dependabot ignore Quarkus 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
   - match:
       dependency_name: "io.quarkus:quarkus-universe-bom"
       # Quarkus 2 requires Java 11, which is too high.
-      version_requirement: ">=2.0.0.Final"
+      version_requirement: "2.x"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
   - match:
       dependency_name: "io.quarkus:quarkus-universe-bom"
       # Quarkus 2 requires Java 11, which is too high.
-      version_requirement: "2.x"
+      version_requirement: "[2.0.0.Final,)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
   - match:
       dependency_name: "io.quarkus:quarkus-universe-bom"
       # Quarkus 2 requires Java 11, which is too high.
-      version_requirement: "[2.0.0.Final,)"
+      version_requirement: "2.x"


### PR DESCRIPTION
Quarkus 2.x version update PRs are still being created by dependabot. Follow up to #294.