### PR TITLE
Adjusting Mockito 4.0 with ArgumentMatchers

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerForeignKeyExporterTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerForeignKeyExporterTests.java
@@ -19,7 +19,7 @@
 package com.google.cloud.spanner.hibernate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.12.4</version>
+      <version>4.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate/pull/328  failed. As per the release note (https://github.com/mockito/mockito/releases), Mockito 4.0 dropped Matchers in favor of ArgumentMatchers.

