### PR TITLE
Upgrade hibernate to 5.6.5.Final and fix compilation errors

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerUniqueDelegate.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerUniqueDelegate.java
@@ -19,6 +19,7 @@
 package com.google.cloud.spanner.hibernate;
 
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.unique.DefaultUniqueDelegate;
 import org.hibernate.mapping.Index;
@@ -40,14 +41,16 @@ public class SpannerUniqueDelegate extends DefaultUniqueDelegate {
   }
 
   @Override
-  public String getAlterTableToAddUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata) {
-    return Index.buildSqlCreateIndexString(
-        dialect, uniqueKey.getName(), uniqueKey.getTable(), uniqueKey.columnIterator(),
+  public String getAlterTableToAddUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata,
+      SqlStringGenerationContext context) {
+    return Index.buildSqlCreateIndexString(context,
+        uniqueKey.getName(), uniqueKey.getTable(), uniqueKey.getColumnIterator(),
         uniqueKey.getColumnOrderMap(), true, metadata);
   }
 
   @Override
-  public String getAlterTableToDropUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata) {
+  public String getAlterTableToDropUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata,
+      SqlStringGenerationContext context) {
     StringBuilder buf = new StringBuilder("DROP INDEX ");
     buf.append(dialect.quote(uniqueKey.getName()));
     return buf.toString();

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerForeignKeyExporter.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerForeignKeyExporter.java
@@ -19,6 +19,7 @@
 package com.google.cloud.spanner.hibernate.schema;
 
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.tool.schema.internal.StandardForeignKeyExporter;
@@ -39,14 +40,15 @@ public class SpannerForeignKeyExporter extends StandardForeignKeyExporter {
   }
 
   @Override
-  public String[] getSqlDropStrings(ForeignKey foreignKey, Metadata metadata) {
+  public String[] getSqlDropStrings(ForeignKey foreignKey, Metadata metadata,
+      SqlStringGenerationContext context) {
     if (spannerDatabaseInfo == null) {
       throw new IllegalStateException(
           "Cannot determine which foreign keys to drop because spannerDatabaseInfo was null.");
     }
 
     if (foreignKeyExists(foreignKey)) {
-      return super.getSqlDropStrings(foreignKey, metadata);
+      return super.getSqlDropStrings(foreignKey, metadata, context);
     } else {
       return new String[0];
     }

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedUpdateTableStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedUpdateTableStatementsTests.java
@@ -94,9 +94,6 @@ public class GeneratedUpdateTableStatementsTests {
     List<String> sqlStrings = mockConnection.getStatementResultSetHandler().getExecutedStatements();
     assertThat(sqlStrings).containsExactly(
         "START BATCH DDL",
-        "alter table Employee ADD COLUMN id INT64 not null",
-        "alter table Employee ADD COLUMN name STRING(255)",
-        "alter table Employee ADD COLUMN manager_id INT64",
         "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
         "create index name_index on Employee (name)",
         "alter table Employee add constraint FKiralam2duuhr33k8a10aoc2t6 "
@@ -104,6 +101,8 @@ public class GeneratedUpdateTableStatementsTests {
         "RUN BATCH",
         "INSERT INTO hibernate_sequence (next_val) VALUES(1)"
     );
+
+    mockConnection.close();
   }
 
   /**

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedUpdateTableStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedUpdateTableStatementsTests.java
@@ -90,8 +90,10 @@ public class GeneratedUpdateTableStatementsTests {
   @Test
   public void testUpdateStatements_alterTables() throws SQLException {
     setupTestTables("Employee");
-
     List<String> sqlStrings = mockConnection.getStatementResultSetHandler().getExecutedStatements();
+    // The "alter table Employee ADD COLUMN" statements are no longer included in the generated
+    // schema when updating an existing table. This schema change was introduced from Hibernate
+    // 5.5.2 onwards.
     assertThat(sqlStrings).containsExactly(
         "START BATCH DDL",
         "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedUpdateTableStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedUpdateTableStatementsTests.java
@@ -101,8 +101,6 @@ public class GeneratedUpdateTableStatementsTests {
         "RUN BATCH",
         "INSERT INTO hibernate_sequence (next_val) VALUES(1)"
     );
-
-    mockConnection.close();
   }
 
   /**

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerForeignKeyExporterTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerForeignKeyExporterTests.java
@@ -76,7 +76,7 @@ public class SpannerForeignKeyExporterTests {
   @Test
   public void testDropMissingForeignKey_missingTable() {
     String[] dropStatements = spannerForeignKeyExporter.getSqlDropStrings(
-        foreignKey("person", "person_fk"), metadata, context);
+        foreignKey("person", "person_fk"), metadata, this.context);
     assertThat(dropStatements).isEmpty();
   }
 

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
@@ -92,10 +92,10 @@ public class SpannerTableExporterTests {
     List<String> statements = Files.readAllLines(scriptFile.toPath());
     assertThat(statements)
         .containsExactly(
-            "START BATCH DDL",
-            "drop table `TestEntity_stringList`",
-            "drop table `test_table`",
-            "RUN BATCH");
+            "START BATCH DDL;",
+            "drop table `TestEntity_stringList`;",
+            "drop table `test_table`;",
+            "RUN BATCH;");
   }
 
   @Test
@@ -115,11 +115,11 @@ public class SpannerTableExporterTests {
     List<String> statements = Files.readAllLines(scriptFile.toPath());
 
     assertThat(statements).containsExactly(
-        "START BATCH DDL",
-        "drop index name_index",
-        "drop table Employee",
-        "drop table hibernate_sequence",
-        "RUN BATCH");
+        "START BATCH DDL;",
+        "drop index name_index;",
+        "drop table Employee;",
+        "drop table hibernate_sequence;",
+        "RUN BATCH;");
   }
 
   @Test
@@ -139,13 +139,13 @@ public class SpannerTableExporterTests {
 
     assertThat(statements).containsExactly(
         // This omits creating the Employee table since it is declared to exist in metadata.
-        "START BATCH DDL",
-        "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
-        "create index name_index on Employee (name)",
+        "START BATCH DDL;",
+        "create table hibernate_sequence (next_val INT64) PRIMARY KEY ();",
+        "create index name_index on Employee (name);",
         "alter table Employee add constraint FKiralam2duuhr33k8a10aoc2t6 "
-            + "foreign key (manager_id) references Employee (id)",
-        "RUN BATCH",
-        "INSERT INTO hibernate_sequence (next_val) VALUES(1)"
+            + "foreign key (manager_id) references Employee (id);",
+        "RUN BATCH;",
+        "INSERT INTO hibernate_sequence (next_val) VALUES(1);"
     );
   }
 
@@ -163,22 +163,22 @@ public class SpannerTableExporterTests {
     // implementation maps types.
     String expectedCreateString = "create table `test_table` (`ID1` INT64 not null,id2"
         + " STRING(255) not null,`boolColumn` BOOL,longVal INT64 not null,stringVal"
-        + " STRING(255)) PRIMARY KEY (`ID1`,id2)";
+        + " STRING(255)) PRIMARY KEY (`ID1`,id2);";
 
     String expectedCollectionCreateString = "create table `TestEntity_stringList` "
         + "(`TestEntity_ID1` INT64 not null,`TestEntity_id2` STRING(255) not null,"
-        + "stringList STRING(255)) PRIMARY KEY (`TestEntity_ID1`,`TestEntity_id2`,stringList)";
+        + "stringList STRING(255)) PRIMARY KEY (`TestEntity_ID1`,`TestEntity_id2`,stringList);";
 
     String foreignKeyString =
         "alter table `TestEntity_stringList` add constraint FK2is6fwy3079dmfhjot09x5och "
             + "foreign key (`TestEntity_ID1`, `TestEntity_id2`) "
-            + "references `test_table` (`ID1`, id2)";
+            + "references `test_table` (`ID1`, id2);";
 
-    assertThat(statements.get(0)).isEqualTo("START BATCH DDL");
+    assertThat(statements.get(0)).isEqualTo("START BATCH DDL;");
     assertThat(statements.subList(1, 4))
         .containsExactlyInAnyOrder(
             expectedCreateString, expectedCollectionCreateString, foreignKeyString);
-    assertThat(statements.get(4)).isEqualTo("RUN BATCH");
+    assertThat(statements.get(4)).isEqualTo("RUN BATCH;");
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.3.0</version>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <hibernate.version>5.4.29.Final</hibernate.version>
+    <hibernate.version>5.6.5.Final</hibernate.version>
     <spanner-jdbc-driver.version>2.5.8</spanner-jdbc-driver.version>
     <log4j.version>2.17.1</log4j.version>
 


### PR DESCRIPTION
 Running `./mvnw verify -f google-cloud-spanner-hibernate-testing/pom.xml -Dhibernate.show_sql=false -Dhibernate.connection.url='jdbc:cloudspanner:/projects/cloud-spanner-hibernate-ci/instances/test-instance/databases/test-database'`  locally results in a successful build.


