### PR TITLE
[Not for merge] Test to confirm null in JSON column

### DIFF
--- a/google-cloud-spanner-hibernate-testing/src/test/java/org/hibernate/dialect/JsonColumnTypeTest.java
+++ b/google-cloud-spanner-hibernate-testing/src/test/java/org/hibernate/dialect/JsonColumnTypeTest.java
@@ -40,6 +40,26 @@ public class JsonColumnTypeTest extends BaseEntityManagerFunctionalTestCase {
     });
   }
 
+  @Test
+  public void jsonColumnTestNullJsonColumn() {
+    doInJPA(this::entityManagerFactory, entityManager -> {
+      JsonEntity jsonEntity = new JsonEntity();
+      jsonEntity.setEmployee(null);
+
+      entityManager.persist(jsonEntity);
+      entityManager.flush();
+
+      Session session = entityManager.unwrap(Session.class);
+      List<JsonEntity> entities =
+          session.createQuery(
+              "from JsonEntity", JsonEntity.class).list();
+      assertThat(entities).hasSizeGreaterThan(0);
+
+      JsonEntity entity = entities.get(0);
+      assertThat(entity.getEmployee()).isNull();
+    });
+  }
+
   private static Employee createEmployee() {
     Employee employee = new Employee();
     employee.setName("Helen");


### PR DESCRIPTION
This is an investigation for https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate/issues/381.

This test case ` jsonColumnTestNullJsonColumn` fails with the same error message as https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate/issues/381.

```
java.lang.IllegalArgumentException: Unsupported sql type for setting to null: 100011

	at com.google.cloud.spanner.jdbc.JdbcParameterStore.setNullValue(JdbcParameterStore.java:948)
	at com.google.cloud.spanner.jdbc.JdbcParameterStore.setSingleValue(JdbcParameterStore.java:497)
	at com.google.cloud.spanner.jdbc.JdbcParameterStore.setValue(JdbcParameterStore.java:484)
	at com.google.cloud.spanner.jdbc.JdbcParameterStore.bindParameterValue(JdbcParameterStore.java:466)
	at com.google.cloud.spanner.jdbc.JdbcPreparedStatement.createStatement(JdbcPreparedStatement.java:56)
	at com.google.cloud.spanner.jdbc.JdbcPreparedStatement.addBatch(JdbcPreparedStatement.java:93)
	at org.hibernate.engine.jdbc.batch.internal.BatchingBatch.addToBatch(BatchingBatch.java:78)
	at org.hibernate.persister.entity.AbstractEntityPersister.insert(AbstractEntityPersister.java:3291)
	at org.hibernate.persister.entity.AbstractEntityPersister.insert(AbstractEntityPersister.java:3824)
	at org.hibernate.action.internal.EntityInsertAction.execute(EntityInsertAction.java:107)
	at org.hibernate.engine.spi.ActionQueue.executeActions(ActionQueue.java:604)
	at org.hibernate.engine.spi.ActionQueue.lambda$executeActions$1(ActionQueue.java:478)

```

https://cloud.google.com/spanner/docs/working-with-json#create_a_table_with_a_json_column says

> A JSON column can be added to a table when the table is created. JSON columns can be nullable.
