### PR TITLE
Update dependabot.yml to add "prefix-development" (trying this out)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 version: 2
-updates:
+updates:       
  - package-ecosystem: maven
    directory: "/"
    schedule:
@@ -8,6 +8,7 @@ updates:
    commit-message:
     # Prefix all commit messages from dependabot with "deps:"
      prefix: "deps:"
+     prefix-development: "test(deps):"
    ignore:
      - dependency-name: "io.quarkus:quarkus-universe-bom"
     # Quarkus 2 requires Java 11, which is too high.


### PR DESCRIPTION
I could not find anything substantial in implementing the prefix-development part. I think for each of the package managers that is defined in "package-ecosystem" (like npm, maven etc), there exists a pre-defined development dependency group. And for the dependencies in this group, the prefix in the dependabot version-bump PR commit message will be what we define in "prefix-development" field. Also, the only fields in which we can specify "dependency-name" is either "allow" or "ignore". Now if this is true, there are good chances that the dependencies that we don't want to include exist in the pre-defined development dependency group. I could nowhere find what exists in the development dependency group for maven. Can you please give it a look? Maybe I don't know where to look.
For the time being, I'm opening this PR with prefix-development added to give it a try and see what happens.