### PR TITLE
Fixing breaking changes for microprofile major version bump

### DIFF
--- a/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile</groupId>
       <artifactId>microprofile</artifactId>
-      <version>4.1</version>
+      <version>5.0</version>
       <type>pom</type>
       <scope>provided</scope>
     </dependency>
@@ -42,6 +42,11 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+      <version>3.0.0</version>
     </dependency>
 
   </dependencies>

--- a/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/src/main/java/com/example/microprofile/PersonController.java
+++ b/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/src/main/java/com/example/microprofile/PersonController.java
@@ -18,9 +18,9 @@
 
 package com.example.microprofile;
 
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
 import java.util.UUID;
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 import javax.ws.rs.Consumes;

--- a/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/src/main/java/com/example/microprofile/Producer.java
+++ b/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/src/main/java/com/example/microprofile/Producer.java
@@ -18,10 +18,11 @@
 
 package com.example.microprofile;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
 import javax.persistence.EntityManager;
 import javax.persistence.Persistence;
+
 
 /**
  * Create an {@link EntityManager} bean that can be injected via CDI.


### PR DESCRIPTION
This includes fixes for breaking changes due to microprofile major version bump from 4.1 to 5.0. The incompatibility were mainly due to namespace change from javax to jakarta in the code.