### PR TITLE
Specify individual directories in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     # Quarkus 2 requires Java 11, which is too high.
        versions: ["2.x"]     
  - package-ecosystem: "maven"
-   directory: "/"
+   directory: "/google-cloud-spanner-hibernate-dialect"
    schedule:
     interval: daily
    open-pull-requests-limit: 10
@@ -21,6 +21,18 @@ updates:
     # Prefix all commit messages from dependabot with "deps:"
      prefix: "deps:"
      prefix-development: "test(deps):"
+   ignore:
+     - dependency-name: "io.quarkus:quarkus-universe-bom"
+    # Quarkus 2 requires Java 11, which is too high.
+       versions: ["2.x"]
+ - package-ecosystem: "maven"
+   directory: "/google-cloud-spanner-hibernate-testing"
+   schedule:
+    interval: daily
+   open-pull-requests-limit: 10
+   commit-message:
+    # This module is not deployable; only contains tests
+     prefix: "test(deps):" 
    ignore:
      - dependency-name: "io.quarkus:quarkus-universe-bom"
     # Quarkus 2 requires Java 11, which is too high.


### PR DESCRIPTION
It looks to me that until dependabot/dependabot-core#4364 is implemented, we won't be able to specify a global configuration and a separate "samples" configuration to use a different commit prefix.

Instead, if we want samples to be treated differently (and we do, for semantic versioning), we'll have to enumerate each top level folder with a dedicated configuration. Mildly inconvenient for this repo, but will be a major annoyance for Spring Cloud GCP since it has lots of modules.