### PR TITLE
Adding annotations for snapshot version bumps in pom.xml's

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/pom.xml
+++ b/google-cloud-spanner-hibernate-dialect/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.5.4</version>
+    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate:current} -->
   </parent>
 
   <properties>

--- a/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.5.4</version>
+    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate-samples:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate-samples:current} -->
+    <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released  -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/pom.xml
@@ -2,16 +2,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <artifactId>basic-hibernate-sample</artifactId>
-  <name>Google Cloud Spanner Hibernate Basic Sample</name>
-  <url>https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate</url>
-
   <parent>
-    <artifactId>google-cloud-spanner-hibernate</artifactId>
+    <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
     <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate:current} -->
   </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>Google Cloud Spanner Hibernate Basic Sample</name>
+  <artifactId>basic-hibernate-sample</artifactId>
 
   <dependencies>
     <dependency>

--- a/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/basic-hibernate-sample/pom.xml
@@ -2,15 +2,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <parent>
-    <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
-    <groupId>com.google.cloud</groupId>
-    <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released  -->
-  </parent>
   <modelVersion>4.0.0</modelVersion>
-
-  <name>Google Cloud Spanner Hibernate Basic Sample</name>
   <artifactId>basic-hibernate-sample</artifactId>
+  <name>Google Cloud Spanner Hibernate Basic Sample</name>
+  <url>https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate</url>
+
+  <parent>
+    <artifactId>google-cloud-spanner-hibernate</artifactId>
+    <groupId>com.google.cloud</groupId>
+    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate:current} -->
+  </parent>
 
   <dependencies>
     <dependency>

--- a/google-cloud-spanner-hibernate-samples/basic-spanner-features-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/basic-spanner-features-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.5.4</version>
+    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate-samples:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/basic-spanner-features-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/basic-spanner-features-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released  -->
+    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/basic-spanner-features-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/basic-spanner-features-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate-samples:current} -->
+    <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released  -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.5.4</version>
+    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate-samples:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released  -->
+    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/microprofile-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate-samples:current} -->
+    <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released  -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/pom.xml
@@ -2,20 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.google.cloud</groupId>
-	<artifactId>google-cloud-spanner-hibernate-samples</artifactId><!-- This artifact should not be released -->
-	<version>0.0.1-SNAPSHOT</version>
-	<packaging>pom</packaging>
-	<name>Google Cloud Spanner Hibernate Sample Applications</name>
-	<url>https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate</url>
-
-
 	<parent>
 		<artifactId>google-cloud-spanner-hibernate</artifactId>
 		<groupId>com.google.cloud</groupId>
 		<version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate:current} -->
 	</parent>
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<name>Google Cloud Spanner Hibernate Sample Applications</name>
+	<artifactId>google-cloud-spanner-hibernate-samples</artifactId>
+	<packaging>pom</packaging>
 
 	<modules>
 		<module>basic-hibernate-sample</module>

--- a/google-cloud-spanner-hibernate-samples/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>google-cloud-spanner-hibernate</artifactId>
 		<groupId>com.google.cloud</groupId>
-		<version>1.5.4</version>
+		<version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate:current} -->
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/google-cloud-spanner-hibernate-samples/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/pom.xml
@@ -2,17 +2,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.google.cloud</groupId>
+	<artifactId>google-cloud-spanner-hibernate-samples</artifactId><!-- This artifact should not be released -->
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<name>Google Cloud Spanner Hibernate Sample Applications</name>
+	<url>https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate</url>
+
+
 	<parent>
 		<artifactId>google-cloud-spanner-hibernate</artifactId>
 		<groupId>com.google.cloud</groupId>
 		<version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate:current} -->
 	</parent>
-
-	<modelVersion>4.0.0</modelVersion>
-
-	<name>Google Cloud Spanner Hibernate Sample Applications</name>
-	<artifactId>google-cloud-spanner-hibernate-samples</artifactId>
-	<packaging>pom</packaging>
 
 	<modules>
 		<module>basic-hibernate-sample</module>

--- a/google-cloud-spanner-hibernate-samples/quarkus-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/quarkus-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.5.4</version>
+    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate-samples:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/quarkus-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/quarkus-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released  -->
+    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/quarkus-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/quarkus-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate-samples:current} -->
+    <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released  -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.5.4</version>
+    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate-samples:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released  -->
+    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate-samples:current} -->
+    <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released  -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.5.4</version>
+    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate-samples:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released  -->
+    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-spanner-hibernate-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate-samples:current} -->
+    <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released  -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-spanner-hibernate-testing/pom.xml
+++ b/google-cloud-spanner-hibernate-testing/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>google-cloud-spanner-hibernate</artifactId>
 		<groupId>com.google.cloud</groupId>
-		<version>1.5.4</version>
+		<version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate:current} -->
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-hibernate</artifactId>
   <packaging>pom</packaging>
-  <version>1.5.4</version>
+  <version>1.5.4</version><!-- {x-version-update:google-cloud-spanner-hibernate:current} -->
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This PR is for adding annotations in various pom.xml's so that the release-please snapshot PR can bump the versions wherever required. 
For identifying which pom.xml's need this bump, I have referred to the last manual snapshot bump release [PR](https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate/pull/389).