### PR TITLE
fix: do not ignore exception during schema migration

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
@@ -19,7 +19,10 @@
 package com.google.cloud.spanner.hibernate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
+import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.hibernate.entities.Account;
 import com.google.cloud.spanner.hibernate.entities.Airplane;
 import com.google.cloud.spanner.hibernate.entities.Airport;
@@ -244,5 +247,20 @@ public class GeneratedCreateTableStatementsTests {
             + "foreign key (Airport_id) references Airport (id)",
         "RUN BATCH"
     );
+  }
+
+  @Test
+  public void testRunBatchFails() {
+    this.connection
+        .getStatementResultSetHandler()
+        .prepareThrowsSQLException("RUN BATCH", new SQLException("test exception"));
+    Metadata metadata =
+        new MetadataSources(this.registry).addAnnotatedClass(Account.class).buildMetadata();
+
+    // Without the custom DdlTransactionIsolater that is returned by SpannerSchemaManagementTool,
+    // the SQLException would just be silently ignored by Hibernate.
+    SpannerException spannerException =
+        assertThrows(SpannerException.class, () -> metadata.buildSessionFactory().openSession());
+    assertEquals("UNKNOWN: test exception", spannerException.getMessage());
   }
 }

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
@@ -250,17 +250,26 @@ public class GeneratedCreateTableStatementsTests {
   }
 
   @Test
+  public void testStartBatchDdlFails() {
+    testBatchFailure("START BATCH DDL");
+  }
+
+  @Test
   public void testRunBatchFails() {
+    testBatchFailure("RUN BATCH");
+  }
+
+  private void testBatchFailure(String batchCommand) {
     this.connection
         .getStatementResultSetHandler()
-        .prepareThrowsSQLException("RUN BATCH", new SQLException("test exception"));
+        .prepareThrowsSQLException(batchCommand, new SQLException("test exception"));
     Metadata metadata =
         new MetadataSources(this.registry).addAnnotatedClass(Account.class).buildMetadata();
 
     // Without the custom DdlTransactionIsolater that is returned by SpannerSchemaManagementTool,
     // the SQLException would just be silently ignored by Hibernate.
     SpannerException spannerException =
-        assertThrows(SpannerException.class, () -> metadata.buildSessionFactory().openSession());
+        assertThrows(SpannerException.class, metadata::buildSessionFactory);
     assertEquals("UNKNOWN: test exception", spannerException.getMessage());
   }
 }


### PR DESCRIPTION
The Cloud Spanner Hibernate dialect will include the statements `START BATCH DDL` and `RUN BATCH` as auxiliary database objects. This ensures that the entire schema migration is executed as a single DDL batch, which both improves the execution speed of the statements, as well as makes the parsing of all statements atomic. However, Hibernate will ignore any SQLException that is thrown when creating an auxiliary database object. This means that if the `RUN BATCH` statement returns a SQLException, for example because one of the DDL statements is invalid, Hibernate will just silently ignore the error and proceed as if the schema migration worked.

This is fixed in this PR by returning an exception that is not an instance of `SQLException` specifically when one of the statements `START BATCH DDL` or `RUN BATCH` is executed as part of a schema migration.

Fixes #470