### PR TITLE
feat: support bit-reversed sequences

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/BitReversedSequenceStyleGenerator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/BitReversedSequenceStyleGenerator.java
@@ -18,6 +18,7 @@
 
 package com.google.cloud.spanner.hibernate;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
 import java.util.Properties;
 import org.hibernate.HibernateException;
@@ -160,10 +161,16 @@ public class BitReversedSequenceStyleGenerator extends SequenceStyleGenerator {
   @Override
   public Serializable generate(SharedSessionContractImplementor session, Object object)
       throws HibernateException {
-    Serializable id = super.generate(session, object);
+    Serializable id = generateBaseValue(session, object);
     if (id instanceof Long) {
       return Long.reverse((Long) id);
     }
     return id;
+  }
+
+  @VisibleForTesting
+  protected Serializable generateBaseValue(
+      SharedSessionContractImplementor session, Object object) {
+    return super.generate(session, object);
   }
 }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/BitReversedSequenceStyleGenerator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/BitReversedSequenceStyleGenerator.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate;
+
+import java.io.Serializable;
+import java.util.Properties;
+import org.hibernate.HibernateException;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.model.relational.InitCommand;
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.boot.model.relational.QualifiedName;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.enhanced.DatabaseStructure;
+import org.hibernate.id.enhanced.SequenceStyleGenerator;
+import org.hibernate.id.enhanced.TableStructure;
+import org.hibernate.mapping.Table;
+import org.hibernate.type.Type;
+
+/**
+ * Sequence or table backed ID generator that reverses the bits in the returned sequence value.
+ *
+ * <p>Using a bit-reversed sequence for ID generation is recommended above sequences that return a
+ * monotonically increasing value for Cloud Spanner. This generator also supports both an increment
+ * size larger than 1 and an initial value larger than 1.
+ *
+ * <p>It is recommended to use a separate table for each generator to prevent a large number of
+ * writes for a single ID generator table. Set the table name to use for a generator with the
+ * SequenceStyleGenerator.SEQUENCE_PARAM parameter (see example below).
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * @Id
+ * @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "customerId")
+ * @GenericGenerator(
+ *       name = "customerId",
+ *       strategy = "com.google.cloud.spanner.hibernate.BitReversedSequenceStyleGenerator",
+ *       parameters = {
+ *           @Parameter(name = SequenceStyleGenerator.SEQUENCE_PARAM, value = "customerId"),
+ *           @Parameter(name = SequenceStyleGenerator.INCREMENT_PARAM, value = "1000"),
+ *           @Parameter(name = SequenceStyleGenerator.INITIAL_PARAM, value = "50000") })
+ * @Column(nullable = false)
+ * private Long customerId;
+ * }</pre>
+ */
+public class BitReversedSequenceStyleGenerator extends SequenceStyleGenerator {
+  /** Specific implementation of a backing {@link TableStructure} for bit-reversed sequences. */
+  private static class SpannerSequenceTableStructure extends TableStructure {
+    private final JdbcEnvironment jdbcEnvironment;
+    private final QualifiedName qualifiedName;
+    private final Identifier valueColumnNameIdentifier;
+    private final int initialValue;
+
+    public SpannerSequenceTableStructure(
+        JdbcEnvironment jdbcEnvironment,
+        QualifiedName qualifiedTableName,
+        Identifier valueColumnNameIdentifier,
+        int initialValue,
+        int incrementSize,
+        Class numberType) {
+      super(
+          jdbcEnvironment,
+          qualifiedTableName,
+          valueColumnNameIdentifier,
+          initialValue,
+          incrementSize,
+          numberType);
+      this.jdbcEnvironment = jdbcEnvironment;
+      this.qualifiedName = qualifiedTableName;
+      this.valueColumnNameIdentifier = valueColumnNameIdentifier;
+      this.initialValue = initialValue;
+    }
+
+    @Override
+    public void registerExportables(Database database) {
+      super.registerExportables(database);
+      // Replace the init command for the table-backed sequence.
+      // Hibernate by default generates an 'insert into table_name values (?)' statement.
+      // That is not supported by Cloud Spanner, as Cloud Spanner requires the insert statement to
+      // include the column name(s) that are being used in the insert statement.
+      final Namespace namespace =
+          database.locateNamespace(qualifiedName.getCatalogName(), qualifiedName.getSchemaName());
+      Table table = namespace.locateTable(qualifiedName.getObjectName());
+      if (table != null) {
+        Dialect dialect = jdbcEnvironment.getDialect();
+        String valueColumnNameText = valueColumnNameIdentifier.render(dialect);
+        table.addInitCommand(
+            context ->
+                new ReplaceInitCommand(
+                    "insert into "
+                        + context.format(table.getQualifiedTableName())
+                        + " ("
+                        + valueColumnNameText
+                        + ") values ( "
+                        + initialValue
+                        + " )"));
+      }
+    }
+  }
+
+  /**
+   * Acts as a replacement for other {@link InitCommand}.
+   *
+   * <ol>
+   *   <li>If the list contains at least one {@link ReplaceInitCommand} and at least one normal
+   *       {@link InitCommand}, then all normal {@link InitCommand}s will be ignored during
+   *       execution and only the {@link ReplaceInitCommand}s will be executed.
+   *   <li>If the list only contains {@link ReplaceInitCommand}s, nothing will be executed.
+   *   <li>If the list only contains normal {@link InitCommand}s, all normal {@link InitCommand}s
+   *       will be executed as normal.
+   * </ol>
+   */
+  public static class ReplaceInitCommand extends InitCommand {
+    public ReplaceInitCommand(String... initCommands) {
+      super(initCommands);
+    }
+  }
+
+  @Override
+  protected DatabaseStructure buildTableStructure(
+      Type type,
+      Properties params,
+      JdbcEnvironment jdbcEnvironment,
+      QualifiedName sequenceName,
+      int initialValue,
+      int incrementSize) {
+    final Identifier valueColumnName = determineValueColumnName(params, jdbcEnvironment);
+    return new SpannerSequenceTableStructure(
+        jdbcEnvironment,
+        sequenceName,
+        valueColumnName,
+        initialValue,
+        incrementSize,
+        type.getReturnedClass());
+  }
+
+  /**
+   * Generates a new ID. This uses the normal sequence strategy, but the returned ID is bit-reversed
+   * before it is returned to the application.
+   */
+  @Override
+  public Serializable generate(SharedSessionContractImplementor session, Object object)
+      throws HibernateException {
+    Serializable id = super.generate(session, object);
+    if (id instanceof Long) {
+      return Long.reverse((Long) id);
+    }
+    return id;
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerTableExporter.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerTableExporter.java
@@ -84,9 +84,6 @@ public class SpannerTableExporter implements Exporter<Table> {
     } else if (initCommands.stream().anyMatch(cmd -> cmd instanceof ReplaceInitCommand)) {
       // Only ReplaceInitCommands, but there is nothing to replace, so we return early.
       return;
-    } else {
-      // Only 'normal' InitCommands. Check if some of them are invalid and need to be replaced.
-
     }
     for (InitCommand initCommand : initCommands) {
       addStatementAfterDdlBatch(metadata, initCommand.getInitCommands());

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerTableExporter.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerTableExporter.java
@@ -18,14 +18,19 @@
 
 package com.google.cloud.spanner.hibernate;
 
+import com.google.cloud.spanner.hibernate.BitReversedSequenceStyleGenerator.ReplaceInitCommand;
+import com.google.cloud.spanner.hibernate.schema.RunBatchDdl;
 import com.google.cloud.spanner.hibernate.schema.SpannerDatabaseInfo;
 import com.google.cloud.spanner.hibernate.schema.SpannerTableStatements;
 import com.google.cloud.spanner.hibernate.schema.TableDependencyTracker;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.relational.InitCommand;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Constraint;
 import org.hibernate.mapping.Table;
@@ -55,47 +60,93 @@ public class SpannerTableExporter implements Exporter<Table> {
   }
 
   @Override
-  public String[] getSqlCreateStrings(Table currentTable, Metadata metadata) {
+  public String[] getSqlCreateStrings(
+      Table currentTable, Metadata metadata, SqlStringGenerationContext context) {
     initializeUniqueConstraints(currentTable);
-    return buildSqlStrings(currentTable, metadata, Action.CREATE);
+    List<String> sqlStrings = buildSqlStrings(currentTable, metadata, Action.CREATE);
+
+    applyInitCommands(currentTable, metadata, context);
+
+    return sqlStrings.toArray(new String[0]);
+  }
+
+  protected void applyInitCommands(
+      Table table, Metadata metadata, SqlStringGenerationContext context) {
+    List<InitCommand> initCommands = table.getInitCommands(context);
+    // Use only the replaced commands if the list contains both normal InitCommands and
+    // ReplaceInitCommands.
+    if (initCommands.stream().anyMatch(cmd -> cmd instanceof ReplaceInitCommand)
+        && initCommands.stream().anyMatch(cmd -> !(cmd instanceof ReplaceInitCommand))) {
+      initCommands =
+          initCommands.stream()
+              .filter(cmd -> cmd instanceof ReplaceInitCommand)
+              .collect(Collectors.toList());
+    } else if (initCommands.stream().anyMatch(cmd -> cmd instanceof ReplaceInitCommand)) {
+      // Only ReplaceInitCommands, but there is nothing to replace, so we return early.
+      return;
+    } else {
+      // Only 'normal' InitCommands. Check if some of them are invalid and need to be replaced.
+
+    }
+    for (InitCommand initCommand : initCommands) {
+      addStatementAfterDdlBatch(metadata, initCommand.getInitCommands());
+    }
   }
 
   @Override
   public String[] getSqlDropStrings(Table currentTable, Metadata metadata) {
     initializeUniqueConstraints(currentTable);
-    return buildSqlStrings(currentTable, metadata, Action.DROP);
+    return buildSqlStrings(currentTable, metadata, Action.DROP).toArray(new String[0]);
   }
 
   /**
    * Initializes the table exporter for if a new create-table or drop-table sequence is starting.
    */
   public void init(
-      Metadata metadata,
-      SpannerDatabaseInfo spannerDatabaseInfo,
-      Action schemaAction) {
+      Metadata metadata, SpannerDatabaseInfo spannerDatabaseInfo, Action schemaAction) {
     tableDependencyTracker.initializeDependencies(metadata, schemaAction);
     spannerTableStatements.initializeSpannerDatabaseInfo(spannerDatabaseInfo);
   }
 
-  private String[] buildSqlStrings(Table currentTable, Metadata metadata, Action schemaAction) {
+  private List<String> buildSqlStrings(Table currentTable, Metadata metadata, Action schemaAction) {
     Collection<Table> tablesToProcess = tableDependencyTracker.getDependentTables(currentTable);
 
-    List<String> ddlStatements = tablesToProcess.stream()
-        .flatMap(table -> {
-          if (schemaAction == Action.CREATE) {
-            return spannerTableStatements.createTable(table, metadata).stream();
-          } else {
-            return spannerTableStatements.dropTable(table).stream();
-          }
-        })
+    return tablesToProcess.stream()
+        .flatMap(
+            table -> {
+              if (schemaAction == Action.CREATE) {
+                return spannerTableStatements.createTable(table, metadata).stream();
+              } else {
+                return spannerTableStatements.dropTable(table).stream();
+              }
+            })
         .collect(Collectors.toList());
+  }
 
-    return ddlStatements.toArray(new String[ddlStatements.size()]);
+  static void addStatementAfterDdlBatch(Metadata metadata, String[] statements) {
+    // Find the RunBatchDdl auxiliary object which can run statements after the DDL batch.
+    Optional<RunBatchDdl> runBatchDdl =
+        metadata.getDatabase().getAuxiliaryDatabaseObjects().stream()
+            .filter(obj -> obj instanceof RunBatchDdl)
+            .map(obj -> (RunBatchDdl) obj)
+            .findFirst();
+
+    if (runBatchDdl.isPresent()) {
+      for (String statement : statements) {
+        runBatchDdl.get().addAfterDdlStatement(statement);
+      }
+    } else {
+      throw new IllegalStateException(
+          "Failed to generate statement to execute after DDL batch. "
+              + "The Spanner dialect did not create auxiliary database objects correctly. "
+              + "Please post a question to "
+              + "https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate/issues");
+    }
   }
 
   /**
-   * Processes the columns of the table and creates Unique Constraints for columns
-   * annotated with @Column(unique = true).
+   * Processes the columns of the table and creates Unique Constraints for columns annotated
+   * with @Column(unique = true).
    */
   private static void initializeUniqueConstraints(Table table) {
     Iterator<Column> colIterator = table.getColumnIterator();

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerTableExporter.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerTableExporter.java
@@ -75,13 +75,13 @@ public class SpannerTableExporter implements Exporter<Table> {
     List<InitCommand> initCommands = table.getInitCommands(context);
     // Use only the replaced commands if the list contains both normal InitCommands and
     // ReplaceInitCommands.
-    if (initCommands.stream().anyMatch(cmd -> cmd instanceof ReplaceInitCommand)
-        && initCommands.stream().anyMatch(cmd -> !(cmd instanceof ReplaceInitCommand))) {
+    if (initCommands.stream().anyMatch(ReplaceInitCommand.class::isInstance)
+        && initCommands.stream().anyMatch(cmd -> !ReplaceInitCommand.class.isInstance(cmd))) {
       initCommands =
           initCommands.stream()
-              .filter(cmd -> cmd instanceof ReplaceInitCommand)
+              .filter(ReplaceInitCommand.class::isInstance)
               .collect(Collectors.toList());
-    } else if (initCommands.stream().anyMatch(cmd -> cmd instanceof ReplaceInitCommand)) {
+    } else if (initCommands.stream().anyMatch(ReplaceInitCommand.class::isInstance)) {
       // Only ReplaceInitCommands, but there is nothing to replace, so we return early.
       return;
     }
@@ -124,7 +124,7 @@ public class SpannerTableExporter implements Exporter<Table> {
     // Find the RunBatchDdl auxiliary object which can run statements after the DDL batch.
     Optional<RunBatchDdl> runBatchDdl =
         metadata.getDatabase().getAuxiliaryDatabaseObjects().stream()
-            .filter(obj -> obj instanceof RunBatchDdl)
+            .filter(RunBatchDdl.class::isInstance)
             .map(obj -> (RunBatchDdl) obj)
             .findFirst();
 

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/BitReversedSequenceStyleGeneratorTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/BitReversedSequenceStyleGeneratorTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import com.google.cloud.spanner.hibernate.entities.Customer;
+import java.io.Serializable;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.junit.Test;
+
+/** Tests for {@link BitReversedSequenceStyleGenerator}. */
+public class BitReversedSequenceStyleGeneratorTests {
+
+  @Test
+  public void testIsBitReversed() {
+    SharedSessionContractImplementor session = mock(SharedSessionContractImplementor.class);
+    Customer customer = new Customer();
+    BitReversedSequenceStyleGenerator generator =
+        new BitReversedSequenceStyleGenerator() {
+          protected Serializable generateBaseValue(
+              SharedSessionContractImplementor session, Object entity) {
+            return 0b1111111111111111111111111110000000000000000000000000000010010001L;
+          }
+        };
+    assertEquals(
+        0b1000100100000000000000000000000000000111111111111111111111111111L,
+        generator.generate(session, customer));
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
@@ -27,6 +27,7 @@ import com.google.cloud.spanner.hibernate.entities.Account;
 import com.google.cloud.spanner.hibernate.entities.Airplane;
 import com.google.cloud.spanner.hibernate.entities.Airport;
 import com.google.cloud.spanner.hibernate.entities.Child;
+import com.google.cloud.spanner.hibernate.entities.Customer;
 import com.google.cloud.spanner.hibernate.entities.Employee;
 import com.google.cloud.spanner.hibernate.entities.GrandParent;
 import com.google.cloud.spanner.hibernate.entities.Parent;
@@ -158,6 +159,32 @@ public class GeneratedCreateTableStatementsTests {
         "START BATCH DDL",
         "create table Account (id INT64 not null,amount NUMERIC,name STRING(255)) PRIMARY KEY (id)",
         "RUN BATCH"
+    );
+  }
+
+  @Test
+  public void testCreateBitReversedSequenceTable() {
+    Metadata metadata =
+        new MetadataSources(this.registry)
+            .addAnnotatedClass(Customer.class)
+            .buildMetadata();
+
+    Session session = metadata.buildSessionFactory().openSession();
+    session.beginTransaction();
+    session.close();
+
+    List<String> sqlStrings =
+        this.connection.getStatementResultSetHandler().getExecutedStatements();
+
+    assertThat(sqlStrings).containsExactly(
+        "START BATCH DDL",
+        "RUN BATCH",
+        "START BATCH DDL",
+        "create table Customer "
+            + "(customerId INT64 not null,name STRING(255)) PRIMARY KEY (customerId)",
+        "create table customerId (next_val INT64) PRIMARY KEY ()",
+        "RUN BATCH",
+        "insert into customerId (next_val) values ( 50000 )"
     );
   }
 

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
@@ -20,6 +20,7 @@ package com.google.cloud.spanner.hibernate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.spanner.hibernate.entities.Employee;
 import com.google.cloud.spanner.hibernate.entities.TestEntity;
@@ -212,6 +213,17 @@ public class SpannerTableExporterTests {
         .hasMessage(
             "No identifier specified for entity: "
                 + "com.google.cloud.spanner.hibernate.SpannerTableExporterTests$NoPkEntity");
+  }
+
+  @Test
+  public void testAddStatementAfterDdlBatchFailsWithNoBatch() {
+    Metadata metadata =
+        new MetadataSources(this.registry).addAnnotatedClass(Employee.class).buildMetadata();
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            SpannerTableExporter.addStatementAfterDdlBatch(
+                metadata, new String[] {"insert into foo"}));
   }
 
   @Entity

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/entities/Customer.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/entities/Customer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import org.hibernate.id.enhanced.SequenceStyleGenerator;
+
+/**
+ * A test entity that uses a bit-reversed sequence for ID generation.
+ *
+ * @author loite
+ */
+@Entity
+public class Customer {
+  /**
+   * This ID generator simulates a bit-reversed sequence with an increment size of 1,000 and a start
+   * value of 50,000.
+   *
+   * <ol>
+   *   <li>Starts at 50,000
+   *   <li>Increases by 1,000 each time next_val is called
+   *   <li>The returned value is bit-reversed, meaning that the value will not be monotonically
+   *       increasing
+   * </ol>
+   */
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "customerId")
+  @GenericGenerator(
+      name = "customerId",
+      strategy = "com.google.cloud.spanner.hibernate.BitReversedSequenceStyleGenerator",
+      parameters = {
+        @Parameter(name = SequenceStyleGenerator.INCREMENT_PARAM, value = "1000"),
+        @Parameter(name = SequenceStyleGenerator.SEQUENCE_PARAM, value = "customerId"),
+        @Parameter(name = SequenceStyleGenerator.INITIAL_PARAM, value = "50000")
+      })
+  @Column(nullable = false)
+  private Long customerId;
+
+  private String name;
+}


### PR DESCRIPTION
Adds support for bit-reversed sequences. These are recommended above normal, monotonically increasing sequences for Cloud Spanner, as using a monotonically increasing value for a primary key can cause write hot spots.

This change also fixes the initialization of the backing tables for these sequences. Normally, the Cloud Spanner Hibernate dialect would not insert a value into the table that is backing a sequence, unless it was the default `hibernate_sequence` table. This would mean that generators that used custom table would be generated, but initialized, which would mean that they would not work out of the box.