### PR TITLE
fix: use separate JDBC connection for extraction

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerExtractionContext.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerExtractionContext.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate.schema;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.tool.schema.internal.exec.ImprovedExtractionContextImpl;
+
+/**
+ * {@link SpannerExtractionContext} uses a separate JDBC connection for extracting metadata from the
+ * database. This ensures that no queries are executed on the connection used by the {@link
+ * SpannerSchemaManagementTool} while that connection is in a DDL batch.
+ */
+public class SpannerExtractionContext extends ImprovedExtractionContextImpl {
+  private final JdbcConnectionAccess jdbcConnectionAccess;
+  private Connection extractionConnection;
+
+  SpannerExtractionContext(
+      ServiceRegistry serviceRegistry,
+      JdbcEnvironment jdbcEnvironment,
+      SqlStringGenerationContext sqlStringGenerationContext,
+      DdlTransactionIsolator ddlTransactionIsolator,
+      DatabaseObjectAccess databaseObjectAccess) {
+    super(
+        serviceRegistry,
+        jdbcEnvironment,
+        sqlStringGenerationContext,
+        ddlTransactionIsolator,
+        databaseObjectAccess);
+    this.jdbcConnectionAccess = ddlTransactionIsolator.getJdbcContext().getJdbcConnectionAccess();
+  }
+
+  @Override
+  public Connection getJdbcConnection() {
+    // Get a separate JDBC connection for metadata extraction. This makes sure that Hibernate does
+    // not try to extract metadata using a connection that has an active DDL batch.
+    try {
+      if (extractionConnection == null) {
+        extractionConnection = jdbcConnectionAccess.obtainConnection();
+      }
+    } catch (SQLException ignore) {
+      // Fallback and use the original connection if anything goes wrong.
+      extractionConnection = super.getJdbcConnection();
+    }
+    return extractionConnection;
+  }
+
+  @Override
+  public void cleanup() {
+    super.cleanup();
+    if (extractionConnection != null) {
+      try {
+        extractionConnection.close();
+      } catch (SQLException ignore) {
+        // Nothing we can do, just ignore it.
+      }
+    }
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedUpdateTableStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedUpdateTableStatementsTests.java
@@ -19,12 +19,24 @@
 package com.google.cloud.spanner.hibernate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
+import com.google.cloud.spanner.hibernate.entities.Customer;
 import com.google.cloud.spanner.hibernate.entities.Employee;
+import com.google.cloud.spanner.hibernate.entities.Invoice;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.mockrunner.mock.jdbc.JDBCMockObjectFactory;
 import com.mockrunner.mock.jdbc.MockConnection;
+import com.mockrunner.mock.jdbc.MockDriver;
+import com.mockrunner.mock.jdbc.MockResultSet;
+import com.mockrunner.mock.jdbc.MockResultSetMetaData;
+import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import org.hibernate.Session;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
@@ -33,87 +45,182 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
-/**
- * Verifies correct DDL generation of update table statements.
- */
+/** Verifies correct DDL generation of update table statements. */
 public class GeneratedUpdateTableStatementsTests {
 
   private StandardServiceRegistry registry;
 
   private JDBCMockObjectFactory jdbcMockObjectFactory;
 
-  private MockConnection mockConnection;
+  private MockConnection defaultConnection;
+  private MockConnection ddlBatchMockConnection;
+  private MockConnection extractorMockConnection;
 
-  /**
-   * Set up the metadata for Hibernate to generate schema statements.
-   */
+  /** Set up the metadata for Hibernate to generate schema statements. */
   @Before
   public void setup() {
-    this.jdbcMockObjectFactory = new JDBCMockObjectFactory();
+    this.jdbcMockObjectFactory =
+        new JDBCMockObjectFactory() {
+          @Override
+          public MockDriver createMockDriver() {
+            return new MockDriver() {
+              final List<Connection> connections = new ArrayList<>();
+              int index = 0;
+
+              @Override
+              public void setupConnection(Connection connection) {
+                connections.add(connection);
+              }
+
+              @Override
+              public Connection connect(String url, Properties info) {
+                Connection connection = connections.get(Math.min(index, connections.size() - 1));
+                index++;
+                return connection;
+              }
+            };
+          }
+        };
     this.jdbcMockObjectFactory.registerMockDriver();
 
-    mockConnection = this.jdbcMockObjectFactory.createMockConnection();
+    defaultConnection = this.jdbcMockObjectFactory.getMockConnection();
+    ddlBatchMockConnection = this.jdbcMockObjectFactory.createMockConnection();
+    extractorMockConnection = this.jdbcMockObjectFactory.createMockConnection();
 
-    this.jdbcMockObjectFactory
-        .getMockDriver()
-        .setupConnection(mockConnection);
+    this.jdbcMockObjectFactory.getMockDriver().setupConnection(ddlBatchMockConnection);
+    this.jdbcMockObjectFactory.getMockDriver().setupConnection(extractorMockConnection);
 
-    this.registry = new StandardServiceRegistryBuilder()
-        .applySetting("hibernate.dialect", SpannerDialect.class.getName())
-        // must NOT set a driver class name so that Hibernate will use java.sql.DriverManager
-        // and discover the only mock driver we have set up.
-        .applySetting("hibernate.connection.url", "unused")
-        .applySetting("hibernate.connection.username", "unused")
-        .applySetting("hibernate.connection.password", "unused")
-        .applySetting("hibernate.hbm2ddl.auto", "update")
-        .build();
+    this.registry =
+        new StandardServiceRegistryBuilder()
+            .applySetting("hibernate.dialect", SpannerDialect.class.getName())
+            // must NOT set a driver class name so that Hibernate will use java.sql.DriverManager
+            // and discover the only mock driver we have set up.
+            .applySetting("hibernate.connection.url", "unused")
+            .applySetting("hibernate.connection.username", "unused")
+            .applySetting("hibernate.connection.password", "unused")
+            .applySetting("hibernate.hbm2ddl.auto", "update")
+            .build();
   }
 
   @Test
   public void testUpdateStatements_createTables() throws SQLException {
     setupTestTables("Hello");
 
-    List<String> sqlStrings = mockConnection.getStatementResultSetHandler().getExecutedStatements();
-    assertThat(sqlStrings).containsExactly(
-        "START BATCH DDL",
-        "create table Employee (id INT64 not null,name STRING(255),manager_id INT64) "
-            + "PRIMARY KEY (id)",
-        "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
-        "create index name_index on Employee (name)",
-        "alter table Employee add constraint FKiralam2duuhr33k8a10aoc2t6 "
-            + "foreign key (manager_id) references Employee (id)",
-        "RUN BATCH",
-        "INSERT INTO hibernate_sequence (next_val) VALUES(1)"
-    );
+    List<String> sqlStrings =
+        ddlBatchMockConnection.getStatementResultSetHandler().getExecutedStatements();
+    assertThat(sqlStrings)
+        .containsExactly(
+            "START BATCH DDL",
+            "create table Employee (id INT64 not null,name STRING(255),manager_id INT64) "
+                + "PRIMARY KEY (id)",
+            "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
+            "create index name_index on Employee (name)",
+            "alter table Employee add constraint FKiralam2duuhr33k8a10aoc2t6 "
+                + "foreign key (manager_id) references Employee (id)",
+            "RUN BATCH",
+            "INSERT INTO hibernate_sequence (next_val) VALUES(1)");
   }
 
   @Test
   public void testUpdateStatements_alterTables() throws SQLException {
-    setupTestTables("Employee");
-    List<String> sqlStrings = mockConnection.getStatementResultSetHandler().getExecutedStatements();
+    setupTestTables(ImmutableMap.of("Employee", ImmutableList.of("id", "name", "manager_id")));
+    List<String> sqlStrings =
+        ddlBatchMockConnection.getStatementResultSetHandler().getExecutedStatements();
     // The "alter table Employee ADD COLUMN" statements are no longer included in the generated
     // schema when updating an existing table. This schema change was introduced from Hibernate
     // 5.5.2 onwards.
-    assertThat(sqlStrings).containsExactly(
-        "START BATCH DDL",
-        "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
-        "create index name_index on Employee (name)",
-        "alter table Employee add constraint FKiralam2duuhr33k8a10aoc2t6 "
-            + "foreign key (manager_id) references Employee (id)",
-        "RUN BATCH",
-        "INSERT INTO hibernate_sequence (next_val) VALUES(1)"
-    );
+    assertThat(sqlStrings)
+        .containsExactly(
+            "START BATCH DDL",
+            "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
+            "create index name_index on Employee (name)",
+            "alter table Employee add constraint FKiralam2duuhr33k8a10aoc2t6 "
+                + "foreign key (manager_id) references Employee (id)",
+            "RUN BATCH",
+            "INSERT INTO hibernate_sequence (next_val) VALUES(1)");
   }
 
-  /**
-   * Sets up which pre-existing tables that Hibernate sees.
-   */
+  @Test
+  public void testUpdateStatements_withExistingTables_withForeignKeys() throws SQLException {
+    setupTestTablesWithForeignKeys(
+        ImmutableMap.of(
+            "Customer", ImmutableList.of("customerId", "name"),
+            "customerId", ImmutableList.of("next_val"),
+            "Invoice", ImmutableList.of("invoiceId", "number", "customer_customerId"),
+            "invoiceId", ImmutableList.of("next_val")));
+
+    List<String> sqlStrings =
+        ddlBatchMockConnection.getStatementResultSetHandler().getExecutedStatements();
+    assertThat(sqlStrings).containsExactly("START BATCH DDL", "RUN BATCH");
+    assertEquals(
+        ImmutableList.of(),
+        ddlBatchMockConnection.getPreparedStatementResultSetHandler().getExecutedStatements());
+
+    assertEquals(
+        ImmutableList.of(),
+        extractorMockConnection.getStatementResultSetHandler().getExecutedStatements());
+    assertEquals(
+        ImmutableList.of("select * from `Customer` where 1=0"),
+        extractorMockConnection.getPreparedStatementResultSetHandler().getExecutedStatements());
+  }
+
+  /** Sets up which pre-existing tables that Hibernate sees. */
   private void setupTestTables(String... tables) throws SQLException {
-    mockConnection.setMetaData(MockJdbcUtils.metaDataBuilder().setTables(tables).build());
+    defaultConnection.setMetaData(MockJdbcUtils.metaDataBuilder().setTables(tables).build());
+    extractorMockConnection.setMetaData(MockJdbcUtils.metaDataBuilder().setTables(tables).build());
+
+    Metadata metadata =
+        new MetadataSources(this.registry).addAnnotatedClass(Employee.class).buildMetadata();
+
+    Session session = metadata.buildSessionFactory().openSession();
+    session.beginTransaction();
+    session.close();
+  }
+
+  private void setupTestTables(Map<String, List<String>> tablesAndColumns) throws SQLException {
+    defaultConnection.setMetaData(
+        MockJdbcUtils.metaDataBuilder().setTables(tablesAndColumns).build());
+    extractorMockConnection.setMetaData(
+        MockJdbcUtils.metaDataBuilder().setTables(tablesAndColumns).build());
+
+    Metadata metadata =
+        new MetadataSources(this.registry).addAnnotatedClass(Employee.class).buildMetadata();
+
+    Session session = metadata.buildSessionFactory().openSession();
+    session.beginTransaction();
+    session.close();
+  }
+
+  private void setupTestTablesWithForeignKeys(Map<String, List<String>> tables)
+      throws SQLException {
+    defaultConnection.setMetaData(
+        MockJdbcUtils.metaDataBuilder()
+            .setTables(tables)
+            .setImportedKeys(
+                "Customer", "customerId", "Invoice", "customer_customerId", "fk_invoice_customer")
+            .build());
+    extractorMockConnection.setMetaData(
+        MockJdbcUtils.metaDataBuilder()
+            .setTables(tables)
+            .setImportedKeys(
+                "Customer", "customerId", "Invoice", "customer_customerId", "fk_invoice_customer")
+            .build());
+    MockResultSetMetaData mockResultSetMetaData = new MockResultSetMetaData();
+    mockResultSetMetaData.setColumnCount(2);
+    mockResultSetMetaData.setColumnName(1, "customerId");
+    mockResultSetMetaData.setColumnTypeName(1, "INT64");
+    mockResultSetMetaData.setColumnName(2, "name");
+    mockResultSetMetaData.setColumnTypeName(2, "STRING");
+    MockResultSet resultSet = new MockResultSet("invoice_columns");
+    resultSet.setResultSetMetaData(mockResultSetMetaData);
+    extractorMockConnection
+        .getPreparedStatementResultSetHandler()
+        .prepareResultSet("select * from `Customer` where 1=0", resultSet);
 
     Metadata metadata =
         new MetadataSources(this.registry)
-            .addAnnotatedClass(Employee.class)
+            .addAnnotatedClass(Customer.class)
+            .addAnnotatedClass(Invoice.class)
             .buildMetadata();
 
     Session session = metadata.buildSessionFactory().openSession();

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/entities/Invoice.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/entities/Invoice.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import org.hibernate.id.enhanced.SequenceStyleGenerator;
+
+/**
+ * A test entity that has a many-to-one relationship.
+ *
+ * @author loite
+ */
+@Entity
+public class Invoice {
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "invoiceId")
+  @GenericGenerator(
+      name = "invoiceId",
+      strategy = "com.google.cloud.spanner.hibernate.BitReversedSequenceStyleGenerator",
+      parameters = {
+          @Parameter(name = SequenceStyleGenerator.INCREMENT_PARAM, value = "1000"),
+          @Parameter(name = SequenceStyleGenerator.SEQUENCE_PARAM, value = "invoiceId"),
+          @Parameter(name = SequenceStyleGenerator.INITIAL_PARAM, value = "1")
+      })
+  @Column(nullable = false)
+  private Long invoiceId;
+
+  private String number;
+
+  @ManyToOne
+  @JoinColumn(foreignKey = @ForeignKey(name = "fk_invoice_customer"))
+  private Customer customer;
+
+}

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/schema/SpannerExtractionContextTest.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/schema/SpannerExtractionContextTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate.schema;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.tool.schema.extract.spi.ExtractionContext.DatabaseObjectAccess;
+import org.hibernate.tool.schema.internal.exec.JdbcContext;
+import org.junit.Test;
+
+/** Tests for {@link SpannerExtractionContext}. */
+public class SpannerExtractionContextTest {
+
+  @Test
+  public void testGetJdbcConnection_obtainsNewConnection() throws SQLException {
+    DdlTransactionIsolator ddlTransactionIsolator = mock(DdlTransactionIsolator.class);
+    JdbcContext jdbcContext = mock(JdbcContext.class);
+    JdbcConnectionAccess jdbcConnectionAccess = mock(JdbcConnectionAccess.class);
+    Connection connection = mock(Connection.class);
+    when(ddlTransactionIsolator.getJdbcContext()).thenReturn(jdbcContext);
+    when(jdbcContext.getJdbcConnectionAccess()).thenReturn(jdbcConnectionAccess);
+
+    when(jdbcConnectionAccess.obtainConnection()).thenReturn(connection);
+    SpannerExtractionContext context =
+        new SpannerExtractionContext(
+            mock(ServiceRegistry.class),
+            mock(JdbcEnvironment.class),
+            mock(SqlStringGenerationContext.class),
+            ddlTransactionIsolator,
+            mock(DatabaseObjectAccess.class));
+
+    assertSame(connection, context.getJdbcConnection());
+  }
+
+  @Test
+  public void testGetJdbcConnection_fallbacksToDdlConnectionOnException() throws SQLException {
+    DdlTransactionIsolator ddlTransactionIsolator = mock(DdlTransactionIsolator.class);
+    JdbcContext jdbcContext = mock(JdbcContext.class);
+    JdbcConnectionAccess jdbcConnectionAccess = mock(JdbcConnectionAccess.class);
+    Connection ddlConnection = mock(Connection.class);
+    when(ddlTransactionIsolator.getJdbcContext()).thenReturn(jdbcContext);
+    when(jdbcContext.getJdbcConnectionAccess()).thenReturn(jdbcConnectionAccess);
+    when(ddlTransactionIsolator.getIsolatedConnection()).thenReturn(ddlConnection);
+
+    when(jdbcConnectionAccess.obtainConnection()).thenThrow(new SQLException("test"));
+    SpannerExtractionContext context =
+        new SpannerExtractionContext(
+            mock(ServiceRegistry.class),
+            mock(JdbcEnvironment.class),
+            mock(SqlStringGenerationContext.class),
+            ddlTransactionIsolator,
+            mock(DatabaseObjectAccess.class));
+
+    assertSame(ddlConnection, context.getJdbcConnection());
+  }
+
+  @Test
+  public void testCleanupClosesConnection() throws SQLException {
+    DdlTransactionIsolator ddlTransactionIsolator = mock(DdlTransactionIsolator.class);
+    JdbcContext jdbcContext = mock(JdbcContext.class);
+    JdbcConnectionAccess jdbcConnectionAccess = mock(JdbcConnectionAccess.class);
+    Connection connection = mock(Connection.class);
+    when(ddlTransactionIsolator.getJdbcContext()).thenReturn(jdbcContext);
+    when(jdbcContext.getJdbcConnectionAccess()).thenReturn(jdbcConnectionAccess);
+
+    when(jdbcConnectionAccess.obtainConnection()).thenReturn(connection);
+    SpannerExtractionContext context =
+        new SpannerExtractionContext(
+            mock(ServiceRegistry.class),
+            mock(JdbcEnvironment.class),
+            mock(SqlStringGenerationContext.class),
+            ddlTransactionIsolator,
+            mock(DatabaseObjectAccess.class));
+
+    // Ensure that we initialize a connection.
+    context.getJdbcConnection();
+    context.cleanup();
+
+    verify(connection).close();
+  }
+
+  @Test
+  public void testCleanupIsNoOpWithoutConnection() throws SQLException {
+    DdlTransactionIsolator ddlTransactionIsolator = mock(DdlTransactionIsolator.class);
+    JdbcContext jdbcContext = mock(JdbcContext.class);
+    JdbcConnectionAccess jdbcConnectionAccess = mock(JdbcConnectionAccess.class);
+    Connection connection = mock(Connection.class);
+    when(ddlTransactionIsolator.getJdbcContext()).thenReturn(jdbcContext);
+    when(jdbcContext.getJdbcConnectionAccess()).thenReturn(jdbcConnectionAccess);
+
+    when(jdbcConnectionAccess.obtainConnection()).thenReturn(connection);
+    SpannerExtractionContext context =
+        new SpannerExtractionContext(
+            mock(ServiceRegistry.class),
+            mock(JdbcEnvironment.class),
+            mock(SqlStringGenerationContext.class),
+            ddlTransactionIsolator,
+            mock(DatabaseObjectAccess.class));
+
+    // Cleaning up without ever having used the context should be no-op.
+    context.cleanup();
+
+    verify(connection, never()).close();
+  }
+
+  @Test
+  public void testCleanupIgnoresException() throws SQLException {
+    DdlTransactionIsolator ddlTransactionIsolator = mock(DdlTransactionIsolator.class);
+    JdbcContext jdbcContext = mock(JdbcContext.class);
+    JdbcConnectionAccess jdbcConnectionAccess = mock(JdbcConnectionAccess.class);
+    Connection connection = mock(Connection.class);
+    when(ddlTransactionIsolator.getJdbcContext()).thenReturn(jdbcContext);
+    when(jdbcContext.getJdbcConnectionAccess()).thenReturn(jdbcConnectionAccess);
+    when(jdbcConnectionAccess.obtainConnection()).thenReturn(connection);
+    doThrow(new SQLException("test")).when(connection).close();
+    SpannerExtractionContext context =
+        new SpannerExtractionContext(
+            mock(ServiceRegistry.class),
+            mock(JdbcEnvironment.class),
+            mock(SqlStringGenerationContext.class),
+            ddlTransactionIsolator,
+            mock(DatabaseObjectAccess.class));
+
+    context.getJdbcConnection();
+    // Cleanup should ignore any errors.
+    context.cleanup();
+    verify(connection).close();
+  }
+}


### PR DESCRIPTION
Use a separate JDBC connection to extract additional metadata from the database. This prevents `Executing queries is not allowed for DDL batches` errors from occurring.

Fixes #480