### PR TITLE
feat: [WIP] add interceptor that enables Mutation usage

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/pom.xml
+++ b/google-cloud-spanner-hibernate-dialect/pom.xml
@@ -26,6 +26,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner-jdbc</artifactId>
+      <version>2.8.1-SNAPSHOT</version>
     </dependency>
 
     <!-- Used for reflection utilities -->

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerMutationsInterceptor.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerMutationsInterceptor.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019-2022 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate;
+
+import com.google.cloud.spanner.jdbc.CloudSpannerJdbcConnection;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import org.hibernate.EmptyInterceptor;
+import org.hibernate.Transaction;
+import org.hibernate.engine.transaction.internal.TransactionImpl;
+import org.hibernate.internal.AbstractSharedSessionContract;
+import org.hibernate.internal.SessionImpl;
+import org.hibernate.resource.jdbc.spi.JdbcSessionOwner;
+
+/**
+ * Interceptor that can be used in combination with the Cloud Spanner Hibernate dialect to instruct
+ * the Cloud Spanner JDBC driver to use mutations instead of DML. This can increase the performance
+ * of the application.
+ */
+public class SpannerMutationsInterceptor extends EmptyInterceptor {
+  private AbstractSharedSessionContract session;
+  private final Method flushBeforeTransactionCompletion;
+  private boolean changedMutationsConversion = false;
+
+  /** Public constructor is necessary for instantiation by reflection. */
+  public SpannerMutationsInterceptor() {
+    Method method;
+    try {
+      method = JdbcSessionOwner.class.getDeclaredMethod("flushBeforeTransactionCompletion");
+    } catch (NoSuchMethodException e) {
+      method = null;
+    }
+    flushBeforeTransactionCompletion = method;
+  }
+
+  @Override
+  public void afterTransactionBegin(Transaction tx) {
+    if (tx instanceof TransactionImpl) {
+      TransactionImpl transaction = (TransactionImpl) tx;
+      try {
+        Field sessionField = TransactionImpl.class.getDeclaredField("session");
+        sessionField.setAccessible(true);
+        session = (AbstractSharedSessionContract) sessionField.get(transaction);
+      } catch (Throwable ignore) {
+        // Do nothing and continue.
+      }
+    }
+  }
+
+  @Override
+  public void preFlush(Iterator entities) {
+    // Switch to mutations if the flush is triggered by a commit, as we then know that these changes
+    // will not be read by this transaction after the flush.
+    if (session != null && isFlushTriggeredByCommit()) {
+      session.doWork(
+          connection -> {
+            CloudSpannerJdbcConnection cloudSpannerJdbcConnection =
+                connection.unwrap(CloudSpannerJdbcConnection.class);
+            if (cloudSpannerJdbcConnection != null
+                && !cloudSpannerJdbcConnection.isConvertDmlToMutations()) {
+              changedMutationsConversion = true;
+              cloudSpannerJdbcConnection.setConvertDmlToMutations(true);
+            }
+          });
+    }
+  }
+
+  @Override
+  public void afterTransactionCompletion(Transaction tx) {
+    if (changedMutationsConversion && session != null) {
+      session.doWork(
+          connection -> {
+            CloudSpannerJdbcConnection cloudSpannerJdbcConnection =
+                connection.unwrap(CloudSpannerJdbcConnection.class);
+            if (cloudSpannerJdbcConnection != null) {
+              cloudSpannerJdbcConnection.setConvertDmlToMutations(false);
+              // Reset the flag here, as there could in theory be multiple flushes for one session.
+              changedMutationsConversion = false;
+            }
+          });
+    }
+  }
+
+  boolean isFlushTriggeredByCommit() {
+    // Unfortunately there is no good way to get information on why a flush was triggered, other
+    // than looking at the callstack. We know that all flushes that are triggered by a commit go
+    // through the method xyz.
+    if (flushBeforeTransactionCompletion == null) {
+      return false;
+    }
+    StackTraceElement[] stackElements = Thread.currentThread().getStackTrace();
+    for (StackTraceElement stack : stackElements) {
+      if (SessionImpl.class.getName().equals(stack.getClassName())
+          && stack.getMethodName().equals(flushBeforeTransactionCompletion.getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/batch/ForwardingBatch.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/batch/ForwardingBatch.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019-2022 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate.batch;
+
+import java.sql.PreparedStatement;
+import org.hibernate.engine.jdbc.batch.spi.Batch;
+import org.hibernate.engine.jdbc.batch.spi.BatchKey;
+import org.hibernate.engine.jdbc.batch.spi.BatchObserver;
+
+/** Batch implementation that forwards all operations to a delegate. */
+abstract class ForwardingBatch implements Batch {
+  protected abstract Batch delegate();
+
+  @Override
+  public BatchKey getKey() {
+    return delegate().getKey();
+  }
+
+  @Override
+  public void addObserver(BatchObserver observer) {
+    delegate().addObserver(observer);
+  }
+
+  @Override
+  public PreparedStatement getBatchStatement(String sql, boolean callable) {
+    return delegate().getBatchStatement(sql, callable);
+  }
+
+  @Override
+  public void addToBatch() {
+    delegate().addToBatch();
+  }
+
+  @Override
+  public void execute() {
+    delegate().execute();
+  }
+
+  @Override
+  public void release() {
+    delegate().release();
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/batch/ForwardingPreparedStatement.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/batch/ForwardingPreparedStatement.java
@@ -1,0 +1,547 @@
+/*
+ * Copyright 2019-2022 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate.batch;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.ParameterMetaData;
+import java.sql.PreparedStatement;
+import java.sql.Ref;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+
+/** {@link PreparedStatement} implementation that forwards all operations to a delegate. */
+abstract class ForwardingPreparedStatement implements PreparedStatement {
+  protected abstract PreparedStatement delegate();
+
+  @Override
+  public void close() throws SQLException {
+    delegate().close();
+  }
+
+  @Override
+  public int getMaxFieldSize() throws SQLException {
+    return delegate().getMaxFieldSize();
+  }
+
+  @Override
+  public void setMaxFieldSize(int max) throws SQLException {
+    delegate().setMaxFieldSize(max);
+  }
+
+  @Override
+  public int getMaxRows() throws SQLException {
+    return delegate().getMaxRows();
+  }
+
+  @Override
+  public void setMaxRows(int max) throws SQLException {
+    delegate().setMaxRows(max);
+  }
+
+  @Override
+  public void setEscapeProcessing(boolean enable) throws SQLException {
+    delegate().setEscapeProcessing(enable);
+  }
+
+  @Override
+  public int getQueryTimeout() throws SQLException {
+    return delegate().getQueryTimeout();
+  }
+
+  @Override
+  public void setQueryTimeout(int seconds) throws SQLException {
+    delegate().setQueryTimeout(seconds);
+  }
+
+  @Override
+  public void cancel() throws SQLException {
+    delegate().cancel();
+  }
+
+  @Override
+  public SQLWarning getWarnings() throws SQLException {
+    return delegate().getWarnings();
+  }
+
+  @Override
+  public void clearWarnings() throws SQLException {
+    delegate().clearWarnings();
+  }
+
+  @Override
+  public void setCursorName(String name) throws SQLException {
+    delegate().setCursorName(name);
+  }
+
+  @Override
+  public ResultSet getResultSet() throws SQLException {
+    return delegate().getResultSet();
+  }
+
+  @Override
+  public int getUpdateCount() throws SQLException {
+    return delegate().getUpdateCount();
+  }
+
+  @Override
+  public boolean getMoreResults() throws SQLException {
+    return delegate().getMoreResults();
+  }
+
+  @Override
+  public boolean getMoreResults(int current) throws SQLException {
+    return delegate().getMoreResults(current);
+  }
+
+  @Override
+  public void setFetchDirection(int direction) throws SQLException {
+    delegate().setFetchDirection(direction);
+  }
+
+  @Override
+  public int getFetchDirection() throws SQLException {
+    return delegate().getFetchDirection();
+  }
+
+  @Override
+  public void setFetchSize(int rows) throws SQLException {
+    delegate().setFetchSize(rows);
+  }
+
+  @Override
+  public int getFetchSize() throws SQLException {
+    return delegate().getFetchSize();
+  }
+
+  @Override
+  public int getResultSetConcurrency() throws SQLException {
+    return delegate().getResultSetConcurrency();
+  }
+
+  @Override
+  public int getResultSetType() throws SQLException {
+    return delegate().getResultSetType();
+  }
+
+  @Override
+  public void addBatch(String sql) throws SQLException {
+    delegate().addBatch(sql);
+  }
+
+  @Override
+  public void addBatch() throws SQLException {
+    delegate().addBatch();
+  }
+
+  @Override
+  public void clearBatch() throws SQLException {
+    delegate().clearBatch();
+  }
+
+  @Override
+  public int[] executeBatch() throws SQLException {
+    return delegate().executeBatch();
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    return delegate().getConnection();
+  }
+
+  @Override
+  public ResultSet getGeneratedKeys() throws SQLException {
+    return delegate().getGeneratedKeys();
+  }
+
+  @Override
+  public int executeUpdate(String sql) throws SQLException {
+    return delegate().executeUpdate(sql);
+  }
+
+  @Override
+  public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+    return delegate().executeUpdate(sql, autoGeneratedKeys);
+  }
+
+  @Override
+  public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+    return delegate().executeUpdate(sql, columnIndexes);
+  }
+
+  @Override
+  public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+    return delegate().executeUpdate(sql, columnNames);
+  }
+
+  @Override
+  public int executeUpdate() throws SQLException {
+    return delegate().executeUpdate();
+  }
+
+  @Override
+  public boolean execute(String sql) throws SQLException {
+    return delegate().execute(sql);
+  }
+
+  @Override
+  public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+    return delegate().execute(sql, autoGeneratedKeys);
+  }
+
+  @Override
+  public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+    return delegate().execute(sql, columnIndexes);
+  }
+
+  @Override
+  public boolean execute(String sql, String[] columnNames) throws SQLException {
+    return delegate().execute(sql, columnNames);
+  }
+
+  @Override
+  public boolean execute() throws SQLException {
+    return delegate().execute();
+  }
+
+  @Override
+  public int getResultSetHoldability() throws SQLException {
+    return delegate().getResultSetHoldability();
+  }
+
+  @Override
+  public boolean isClosed() throws SQLException {
+    return delegate().isClosed();
+  }
+
+  @Override
+  public void setPoolable(boolean poolable) throws SQLException {
+    delegate().setPoolable(poolable);
+  }
+
+  @Override
+  public boolean isPoolable() throws SQLException {
+    return delegate().isPoolable();
+  }
+
+  @Override
+  public void closeOnCompletion() throws SQLException {
+    delegate().closeOnCompletion();
+  }
+
+  @Override
+  public boolean isCloseOnCompletion() throws SQLException {
+    return delegate().isCloseOnCompletion();
+  }
+
+  @Override
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    return delegate().unwrap(iface);
+  }
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return delegate().isWrapperFor(iface);
+  }
+
+  @Override
+  public ResultSet executeQuery(String sql) throws SQLException {
+    return delegate().executeQuery(sql);
+  }
+
+  @Override
+  public ResultSet executeQuery() throws SQLException {
+    return delegate().executeQuery();
+  }
+
+  @Override
+  public void setNull(int parameterIndex, int sqlType) throws SQLException {
+    delegate().setNull(parameterIndex, sqlType);
+  }
+
+  @Override
+  public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
+    delegate().setNull(parameterIndex, sqlType, typeName);
+  }
+
+  @Override
+  public void setBoolean(int parameterIndex, boolean x) throws SQLException {
+    delegate().setBoolean(parameterIndex, x);
+  }
+
+  @Override
+  public void setByte(int parameterIndex, byte x) throws SQLException {
+    delegate().setByte(parameterIndex, x);
+  }
+
+  @Override
+  public void setShort(int parameterIndex, short x) throws SQLException {
+    delegate().setShort(parameterIndex, x);
+  }
+
+  @Override
+  public void setInt(int parameterIndex, int x) throws SQLException {
+    delegate().setInt(parameterIndex, x);
+  }
+
+  @Override
+  public void setLong(int parameterIndex, long x) throws SQLException {
+    delegate().setLong(parameterIndex, x);
+  }
+
+  @Override
+  public void setFloat(int parameterIndex, float x) throws SQLException {
+    delegate().setFloat(parameterIndex, x);
+  }
+
+  @Override
+  public void setDouble(int parameterIndex, double x) throws SQLException {
+    delegate().setDouble(parameterIndex, x);
+  }
+
+  @Override
+  public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+    delegate().setBigDecimal(parameterIndex, x);
+  }
+
+  @Override
+  public void setString(int parameterIndex, String x) throws SQLException {
+    delegate().setString(parameterIndex, x);
+  }
+
+  @Override
+  public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+    delegate().setBytes(parameterIndex, x);
+  }
+
+  @Override
+  public void setDate(int parameterIndex, Date x) throws SQLException {
+    delegate().setDate(parameterIndex, x);
+  }
+
+  @Override
+  public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+    delegate().setDate(parameterIndex, x, cal);
+  }
+
+  @Override
+  public void setTime(int parameterIndex, Time x) throws SQLException {
+    delegate().setTime(parameterIndex, x);
+  }
+
+  @Override
+  public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+    delegate().setTime(parameterIndex, x, cal);
+  }
+
+  @Override
+  public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+    delegate().setTimestamp(parameterIndex, x);
+  }
+
+  @Override
+  public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+    delegate().setTimestamp(parameterIndex, x, cal);
+  }
+
+  @Override
+  public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    delegate().setAsciiStream(parameterIndex, x, length);
+  }
+
+  @Override
+  public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
+    delegate().setAsciiStream(parameterIndex, x, length);
+  }
+
+  @Override
+  public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
+    delegate().setAsciiStream(parameterIndex, x);
+  }
+
+  @Override
+  public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    delegate().setUnicodeStream(parameterIndex, x, length);
+  }
+
+  @Override
+  public void clearParameters() throws SQLException {
+    delegate().clearParameters();
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+    delegate().setObject(parameterIndex, x, targetSqlType);
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x) throws SQLException {
+    delegate().setObject(parameterIndex, x);
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)
+      throws SQLException {
+    delegate().setObject(parameterIndex, x, targetSqlType, scaleOrLength);
+  }
+
+  @Override
+  public void setRef(int parameterIndex, Ref x) throws SQLException {
+    delegate().setRef(parameterIndex, x);
+  }
+
+  @Override
+  public void setArray(int parameterIndex, Array x) throws SQLException {
+    delegate().setArray(parameterIndex, x);
+  }
+
+  @Override
+  public ResultSetMetaData getMetaData() throws SQLException {
+    return delegate().getMetaData();
+  }
+
+  @Override
+  public void setURL(int parameterIndex, URL x) throws SQLException {
+    delegate().setURL(parameterIndex, x);
+  }
+
+  @Override
+  public ParameterMetaData getParameterMetaData() throws SQLException {
+    return delegate().getParameterMetaData();
+  }
+
+  @Override
+  public void setRowId(int parameterIndex, RowId x) throws SQLException {
+    delegate().setRowId(parameterIndex, x);
+  }
+
+  @Override
+  public void setNString(int parameterIndex, String value) throws SQLException {
+    delegate().setNString(parameterIndex, value);
+  }
+
+  @Override
+  public void setNCharacterStream(int parameterIndex, Reader value, long length)
+      throws SQLException {
+    delegate().setNCharacterStream(parameterIndex, value, length);
+  }
+
+  @Override
+  public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
+    delegate().setNCharacterStream(parameterIndex, value);
+  }
+
+  @Override
+  public void setNClob(int parameterIndex, NClob value) throws SQLException {
+    delegate().setNClob(parameterIndex, value);
+  }
+
+  @Override
+  public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
+    delegate().setNClob(parameterIndex, reader, length);
+  }
+
+  @Override
+  public void setNClob(int parameterIndex, Reader reader) throws SQLException {
+    delegate().setNClob(parameterIndex, reader);
+  }
+
+  @Override
+  public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
+    delegate().setSQLXML(parameterIndex, xmlObject);
+  }
+
+  @Override
+  public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    delegate().setBinaryStream(parameterIndex, x, length);
+  }
+
+  @Override
+  public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
+    delegate().setBinaryStream(parameterIndex, x);
+  }
+
+  @Override
+  public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
+    delegate().setBinaryStream(parameterIndex, x, length);
+  }
+
+  @Override
+  public void setCharacterStream(int parameterIndex, Reader reader, int length)
+      throws SQLException {
+    delegate().setCharacterStream(parameterIndex, reader, length);
+  }
+
+  @Override
+  public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
+    delegate().setCharacterStream(parameterIndex, reader);
+  }
+
+  @Override
+  public void setCharacterStream(int parameterIndex, Reader reader, long length)
+      throws SQLException {
+    delegate().setCharacterStream(parameterIndex, reader, length);
+  }
+
+  @Override
+  public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
+    delegate().setClob(parameterIndex, reader, length);
+  }
+
+  @Override
+  public void setClob(int parameterIndex, Reader reader) throws SQLException {
+    delegate().setClob(parameterIndex, reader);
+  }
+
+  @Override
+  public void setClob(int parameterIndex, Clob x) throws SQLException {
+    delegate().setClob(parameterIndex, x);
+  }
+
+  @Override
+  public void setBlob(int parameterIndex, InputStream inputStream, long length)
+      throws SQLException {
+    delegate().setBlob(parameterIndex, inputStream, length);
+  }
+
+  @Override
+  public void setBlob(int parameterIndex, Blob x) throws SQLException {
+    delegate().setBlob(parameterIndex, x);
+  }
+
+  @Override
+  public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+    delegate().setBlob(parameterIndex, inputStream);
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/batch/ForwardingTransactionCoordinator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/batch/ForwardingTransactionCoordinator.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019-2022 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate.batch;
+
+import org.hibernate.engine.transaction.spi.IsolationDelegate;
+import org.hibernate.engine.transaction.spi.TransactionObserver;
+import org.hibernate.jpa.spi.JpaCompliance;
+import org.hibernate.resource.transaction.spi.SynchronizationRegistry;
+import org.hibernate.resource.transaction.spi.TransactionCoordinator;
+import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
+
+abstract class ForwardingTransactionCoordinator implements TransactionCoordinator {
+
+  protected abstract TransactionCoordinator delegate();
+
+  @Override
+  public TransactionCoordinatorBuilder getTransactionCoordinatorBuilder() {
+    return delegate().getTransactionCoordinatorBuilder();
+  }
+
+  @Override
+  public TransactionDriver getTransactionDriverControl() {
+    return delegate().getTransactionDriverControl();
+  }
+
+  @Override
+  public SynchronizationRegistry getLocalSynchronizations() {
+    return delegate().getLocalSynchronizations();
+  }
+
+  @Override
+  public JpaCompliance getJpaCompliance() {
+    return delegate().getJpaCompliance();
+  }
+
+  @Override
+  public void explicitJoin() {
+    delegate().explicitJoin();
+  }
+
+  @Override
+  public boolean isJoined() {
+    return delegate().isJoined();
+  }
+
+  @Override
+  public void pulse() {
+    delegate().pulse();
+  }
+
+  @Override
+  public boolean isActive() {
+    return delegate().isActive();
+  }
+
+  @Override
+  public IsolationDelegate createIsolationDelegate() {
+    return delegate().createIsolationDelegate();
+  }
+
+  @Override
+  public void addObserver(TransactionObserver observer) {
+    delegate().addObserver(observer);
+  }
+
+  @Override
+  public void removeObserver(TransactionObserver observer) {
+    delegate().removeObserver(observer);
+  }
+
+  @Override
+  public void setTimeOut(int seconds) {
+    delegate().setTimeOut(seconds);
+  }
+
+  @Override
+  public int getTimeOut() {
+    return delegate().getTimeOut();
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/batch/ForwardingTransactionCoordinatorBuilder.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/batch/ForwardingTransactionCoordinatorBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019-2022 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate.batch;
+
+import org.hibernate.ConnectionAcquisitionMode;
+import org.hibernate.ConnectionReleaseMode;
+import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
+import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
+import org.hibernate.resource.transaction.spi.TransactionCoordinator;
+import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
+import org.hibernate.resource.transaction.spi.TransactionCoordinatorOwner;
+import org.hibernate.tool.schema.internal.exec.JdbcContext;
+
+abstract class ForwardingTransactionCoordinatorBuilder implements TransactionCoordinatorBuilder {
+  protected abstract TransactionCoordinatorBuilder delegate();
+
+  @Override
+  public TransactionCoordinator buildTransactionCoordinator(
+      TransactionCoordinatorOwner owner, Options options) {
+    return delegate().buildTransactionCoordinator(owner, options);
+  }
+
+  @Override
+  public boolean isJta() {
+    return delegate().isJta();
+  }
+
+  @Override
+  public PhysicalConnectionHandlingMode getDefaultConnectionHandlingMode() {
+    return delegate().getDefaultConnectionHandlingMode();
+  }
+
+  @Override
+  public DdlTransactionIsolator buildDdlTransactionIsolator(JdbcContext jdbcContext) {
+    return delegate().buildDdlTransactionIsolator(jdbcContext);
+  }
+
+  @Override
+  public ConnectionAcquisitionMode getDefaultConnectionAcquisitionMode() {
+    return delegate().getDefaultConnectionAcquisitionMode();
+  }
+
+  @Override
+  public ConnectionReleaseMode getDefaultConnectionReleaseMode() {
+    return delegate().getDefaultConnectionReleaseMode();
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/batch/ForwardingTransactionDriver.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/batch/ForwardingTransactionDriver.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019-2022 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate.batch;
+
+import org.hibernate.resource.transaction.spi.TransactionCoordinator.TransactionDriver;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
+
+abstract class ForwardingTransactionDriver implements TransactionDriver {
+  protected abstract TransactionDriver delegate();
+
+  @Override
+  public void begin() {
+    delegate().begin();
+  }
+
+  @Override
+  public void commit() {
+    delegate().commit();
+  }
+
+  @Override
+  public void rollback() {
+    delegate().rollback();
+  }
+
+  @Override
+  public TransactionStatus getStatus() {
+    return delegate().getStatus();
+  }
+
+  @Override
+  public void markRollbackOnly() {
+    delegate().markRollbackOnly();
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/batch/SpannerHibernateOptimizer.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/batch/SpannerHibernateOptimizer.java
@@ -1,0 +1,446 @@
+/*
+ * Copyright 2019-2022 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate.batch;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
+import com.google.common.collect.Maps;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import org.hibernate.HibernateException;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.config.spi.ConfigurationService;
+import org.hibernate.engine.config.spi.StandardConverters;
+import org.hibernate.engine.jdbc.batch.internal.BatchBuilderImpl;
+import org.hibernate.engine.jdbc.batch.spi.Batch;
+import org.hibernate.engine.jdbc.batch.spi.BatchBuilder;
+import org.hibernate.engine.jdbc.batch.spi.BatchKey;
+import org.hibernate.engine.jdbc.batch.spi.BatchObserver;
+import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.event.internal.DefaultFlushEventListener;
+import org.hibernate.event.service.spi.DuplicationStrategy;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.FlushEvent;
+import org.hibernate.integrator.spi.Integrator;
+import org.hibernate.integrator.spi.IntegratorService;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+import org.hibernate.jdbc.Expectation;
+import org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl;
+import org.hibernate.resource.transaction.spi.TransactionCoordinator;
+import org.hibernate.resource.transaction.spi.TransactionCoordinator.TransactionDriver;
+import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
+import org.hibernate.resource.transaction.spi.TransactionCoordinatorOwner;
+import org.hibernate.service.Service;
+import org.hibernate.service.spi.ServiceContributor;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.service.spi.SessionFactoryServiceRegistry;
+
+/** Optimizes batching of DML specifically for Spanner. */
+public class SpannerHibernateOptimizer implements ServiceContributor {
+  @Override
+  public void contribute(StandardServiceRegistryBuilder builder) {
+    // Register an initiator for our custom SpannerService
+    builder.addInitiator(new SpannerServiceInitiator());
+    // Register our customer BatchBuilder. This perform JDBC batch-merging if enabled.
+    builder.addInitiator(new SpannerBatchBuilderInitiator());
+    // If enabled, registers the custom flush handler which coordinates with the BatchBuilder.
+    builder.addService(IntegratorService.class, new SpannerIntegratorService());
+    // Mock transaction coordinator. Proof of concept for a future BatchDML + Auto-Commit
+    // optimization.
+    builder.addService(
+        TransactionCoordinatorBuilder.class, new SpannerTransactionCoordinatorBuilder());
+  }
+
+  /** Service definition for this optimizer. */
+  public interface SpannerService extends Service {
+    void startFlush(FlushEvent event);
+
+    void endFlush(FlushEvent event);
+
+    SpannerInProgressFlush getInProgressFlush(JdbcCoordinator coordinator);
+  }
+
+  private static class SpannerServiceImpl implements SpannerService {
+    private final ConcurrentMap<JdbcCoordinator, SpannerInProgressFlush> flushes =
+        Maps.newConcurrentMap();
+    private final int batchSize;
+
+    public SpannerServiceImpl(int batchSize) {
+      this.batchSize = batchSize;
+    }
+
+    @Override
+    public void startFlush(FlushEvent event) {
+      JdbcCoordinator coordinator = event.getSession().getJdbcCoordinator();
+      SpannerInProgressFlush flush = new SpannerInProgressFlush(coordinator, batchSize);
+      flushes.put(coordinator, flush);
+    }
+
+    @Override
+    public void endFlush(FlushEvent event) {
+      JdbcCoordinator coordinator = event.getSession().getJdbcCoordinator();
+      SpannerInProgressFlush flush = flushes.remove(coordinator);
+      flush.doExecute();
+    }
+
+    @Override
+    public SpannerInProgressFlush getInProgressFlush(JdbcCoordinator coordinator) {
+      return flushes.get(coordinator);
+    }
+  }
+
+  private static class SpannerServiceInitiator implements StandardServiceInitiator<SpannerService> {
+    @Override
+    public Class<SpannerService> getServiceInitiated() {
+      return SpannerService.class;
+    }
+
+    @Override
+    public SpannerService initiateService(Map config, ServiceRegistryImplementor registry) {
+      String option = AvailableSettings.STATEMENT_BATCH_SIZE;
+      int batchSize = ConfigurationHelper.getInt(option, config, 1);
+      return new SpannerServiceImpl(batchSize);
+    }
+  }
+
+  private static class SpannerBatchStatement {
+    private final PreparedStatement statement;
+    private final String sql;
+    // TODO(thunes): Validate expectations at the end of a batch. This will require
+    // changes to java-spanner and java-spanner-jdbc to provide access to the modified
+    // row count results from the ExecuteBatchDml call.
+    private final Expectation expectation;
+
+    public SpannerBatchStatement(PreparedStatement statement, String sql, Expectation expectation) {
+      this.statement = statement;
+      this.sql = sql;
+      this.expectation = expectation;
+    }
+  }
+
+  private static class SpannerInProgressFlush {
+    private final JdbcCoordinator coordinator;
+    private final SqlExceptionHelper exceptionHelper;
+    private final List<SpannerBatchStatement> buffered = new ArrayList<>();
+    private final int batchSize;
+    private SpannerBatchStatement current = null;
+
+    public SpannerInProgressFlush(JdbcCoordinator coordinator, int batchSize) {
+      this.coordinator = coordinator;
+      this.batchSize = batchSize;
+      exceptionHelper =
+          coordinator
+              .getJdbcSessionOwner()
+              .getJdbcSessionContext()
+              .getServiceRegistry()
+              .getService(JdbcServices.class)
+              .getSqlExceptionHelper();
+    }
+
+    PreparedStatement getBatchStatement(String sql, boolean callable, Expectation expectation) {
+      PreparedStatement statement =
+          coordinator.getStatementPreparer().prepareStatement(sql, callable);
+      current = new SpannerBatchStatement(statement, sql, expectation);
+      return statement;
+    }
+
+    void addToBatch(List<BatchObserver> observers) {
+      if (buffered.isEmpty()) {
+        sendControlStatement("START BATCH DML");
+      }
+
+      try {
+        current.statement.executeUpdate();
+        buffered.add(current);
+      } catch (SQLException e) {
+        abortBatch(e);
+        throw exceptionHelper.convert(e, "exception buffering statement in batch", current.sql);
+      } catch (RuntimeException e) {
+        abortBatch(e);
+        throw e;
+      } finally {
+        current = null;
+      }
+
+      if (buffered.size() >= batchSize) {
+        observers.forEach(BatchObserver::batchImplicitlyExecuted);
+        doExecute();
+      }
+    }
+
+    private void doExecute() {
+      if (buffered.size() > 0) {
+        try {
+          sendControlStatement("RUN BATCH");
+        } finally {
+          buffered.clear();
+        }
+      }
+    }
+
+    private void sendControlStatement(String sql) {
+      Connection connection = coordinator.getLogicalConnection().getPhysicalConnection();
+      try {
+        connection.createStatement().execute(sql);
+      } catch (SQLException e) {
+        abortBatch(e);
+        throw exceptionHelper.convert(e, "exception running batch", sql);
+      } catch (RuntimeException e) {
+        abortBatch(e);
+        throw e;
+      }
+    }
+
+    private void abortBatch(Exception cause) {
+      try {
+        if (buffered.size() > 0) {
+          // We do not use sendControlStatment here because it will recursively call
+          // abortBatch on an exception.
+          coordinator
+              .getLogicalConnection()
+              .getPhysicalConnection()
+              .createStatement()
+              .execute("ABORT BATCH");
+        }
+        coordinator.abortBatch();
+      } catch (RuntimeException | SQLException e) {
+        cause.addSuppressed(e);
+      }
+    }
+  }
+
+  private static class SpannerBatch implements Batch {
+    private final SpannerService service;
+    private final BatchKey key;
+    private final JdbcCoordinator coordinator;
+    private final List<BatchObserver> observers = new ArrayList<>();
+
+    public SpannerBatch(SpannerService service, BatchKey key, JdbcCoordinator coordinator) {
+      // TODO(thunes): Copied from Hibernate BatchingBatch
+      if (!key.getExpectation().canBeBatched()) {
+        throw new HibernateException("attempting to batch an operation which cannot be batched");
+      }
+
+      this.service = service;
+      this.key = key;
+      this.coordinator = coordinator;
+    }
+
+    @Override
+    public BatchKey getKey() {
+      return key;
+    }
+
+    @Override
+    public void addObserver(BatchObserver observer) {
+      observers.add(observer);
+    }
+
+    private SpannerInProgressFlush flush() {
+      return Verify.verifyNotNull(
+          service.getInProgressFlush(coordinator), "Spanner in-progress flush record missing");
+    }
+
+    @Override
+    public PreparedStatement getBatchStatement(String sql, boolean callable) {
+      return flush().getBatchStatement(sql, callable, key.getExpectation());
+    }
+
+    @Override
+    public void addToBatch() {
+      flush().addToBatch(observers);
+    }
+
+    @Override
+    public void execute() {
+      // No-op. We ignore all execute() calls and instead rely on implicit batching and a
+      // final "RUN BATCH" at the end of the overall flush operation.
+    }
+
+    @Override
+    public void release() {
+      observers.clear();
+    }
+  }
+
+  /** Service initiator for the Spanner batch optimizer. */
+  public static class SpannerBatchBuilderInitiator
+      implements StandardServiceInitiator<BatchBuilder> {
+
+    @Override
+    public Class<BatchBuilder> getServiceInitiated() {
+      return BatchBuilder.class;
+    }
+
+    @Override
+    public BatchBuilder initiateService(Map config, ServiceRegistryImplementor registry) {
+      SpannerService service = registry.requireService(SpannerService.class);
+      String option = AvailableSettings.STATEMENT_BATCH_SIZE;
+      int batchSize = ConfigurationHelper.getInt(option, config, 1);
+      return new SpannerBatchBuilder(service, batchSize);
+    }
+  }
+
+  /** Specific {@link BatchBuilder} implementation for Spanner. */
+  public static class SpannerBatchBuilder implements BatchBuilder {
+    private final SpannerService service;
+    private final BatchBuilderImpl fallback;
+
+    public SpannerBatchBuilder(SpannerService service, int batchSize) {
+      this.service = service;
+      this.fallback = new BatchBuilderImpl(batchSize);
+    }
+
+    @Override
+    public Batch buildBatch(BatchKey key, JdbcCoordinator coordinator) {
+      if (service.getInProgressFlush(coordinator) != null) {
+        return new SpannerBatch(service, key, coordinator);
+      }
+
+      return fallback.buildBatch(key, coordinator);
+    }
+  }
+
+  private static class SpannerIntegratorService implements IntegratorService {
+    @Override
+    public Iterable<Integrator> getIntegrators() {
+      return Arrays.asList(new SpannerIntegrator());
+    }
+  }
+
+  private static class SpannerIntegrator implements Integrator {
+    private static final String ENABLED_PROPERTY =
+        SpannerHibernateOptimizer.class.getName() + ".enabled";
+
+    @Override
+    public void integrate(
+        Metadata metadata,
+        SessionFactoryImplementor sessionFactory,
+        SessionFactoryServiceRegistry registry) {
+
+      ConfigurationService config = registry.getService(ConfigurationService.class);
+      boolean enabled = config.getSetting(ENABLED_PROPERTY, StandardConverters.BOOLEAN, false);
+      if (enabled) {
+        EventListenerRegistry listeners = registry.getService(EventListenerRegistry.class);
+        listeners.addDuplicationStrategy(
+            new DuplicationStrategy() {
+              @Override
+              public boolean areMatch(Object listener, Object original) {
+                return (listener instanceof SpannerFlushListener)
+                    && (original instanceof DefaultFlushEventListener);
+              }
+
+              @Override
+              public Action getAction() {
+                return Action.REPLACE_ORIGINAL;
+              }
+            });
+        SpannerService service = registry.requireService(SpannerService.class);
+        listeners.appendListeners(EventType.FLUSH, new SpannerFlushListener(service));
+      }
+    }
+
+    @Override
+    public void disintegrate(
+        SessionFactoryImplementor sessionFactory, SessionFactoryServiceRegistry registry) {
+      // No-op
+    }
+  }
+
+  private static class SpannerFlushListener extends DefaultFlushEventListener {
+    private final SpannerService service;
+
+    public SpannerFlushListener(SpannerService service) {
+      this.service = Preconditions.checkNotNull(service);
+    }
+
+    @Override
+    public void onFlush(FlushEvent event) throws HibernateException {
+      try {
+        service.startFlush(event);
+        super.onFlush(event);
+      } finally {
+        service.endFlush(event);
+      }
+    }
+  }
+
+  /** Transaction coordinator that is used for Spanner DML batches. */
+  public static class SpannerTransactionCoordinatorBuilder
+      extends ForwardingTransactionCoordinatorBuilder {
+
+    @Override
+    protected TransactionCoordinatorBuilder delegate() {
+      return JdbcResourceLocalTransactionCoordinatorBuilderImpl.INSTANCE;
+    }
+
+    @Override
+    public TransactionCoordinator buildTransactionCoordinator(
+        TransactionCoordinatorOwner owner, Options options) {
+
+      if (!(owner instanceof JdbcCoordinator)) {
+        throw new UnsupportedOperationException(
+            "SpannerTransactionCoordinator requires JdbcCoordinator session owner");
+      }
+
+      JdbcCoordinator jdbcCoordinator = (JdbcCoordinator) owner;
+      TransactionCoordinator txnDelegate = super.buildTransactionCoordinator(owner, options);
+      TransactionDriver txnDriver = txnDelegate.getTransactionDriverControl();
+
+      return new ForwardingTransactionCoordinator() {
+        @Override
+        protected TransactionCoordinator delegate() {
+          return txnDelegate;
+        }
+
+        @Override
+        public TransactionDriver getTransactionDriverControl() {
+          return new ForwardingTransactionDriver() {
+            @Override
+            protected TransactionDriver delegate() {
+              return txnDriver;
+            }
+
+            @Override
+            public void commit() {
+              // Inform the driver that a flush + commit is about to occur so the
+              // BatchDML RPC can be deferred until commit() is called.
+              Connection connection =
+                  jdbcCoordinator.getLogicalConnection().getPhysicalConnection();
+              super.commit();
+            }
+          };
+        }
+      };
+    }
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/main/resources/META-INF/services/org.hibernate.service.spi.ServiceContributor
+++ b/google-cloud-spanner-hibernate-dialect/src/main/resources/META-INF/services/org.hibernate.service.spi.ServiceContributor
@@ -1,2 +1,2 @@
 com.google.cloud.spanner.hibernate.SpannerServiceContributor
-
+com.google.cloud.spanner.hibernate.batch.SpannerHibernateOptimizer


### PR DESCRIPTION
Work in progress for an experiment to use mutations instead of DML with Hibernate (when possible).

Adds an interceptor that can be used in combination with the Spanner Hibernate dialect to use Mutations instead of DML. Mutations can have a performance advantage compared to DML, but with the drawback that mutations cannot be read during the same transaction. This interceptor therefore by default only uses mutations when a flush is initiated by Hibernate because the transaction is committing. In all other cases the interceptor will remain inactive and Hibernate will continue to use DML.