### PR TITLE
docs: bump versions in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ Maven coordinates for the dialect:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-hibernate-dialect</artifactId>
-  <version>1.6.1</version>
+  <version>1.7.0</version>
 </dependency>
 ----
 
@@ -30,7 +30,7 @@ Maven coordinates for the official https://cloud.google.com/spanner/docs/open-so
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-jdbc</artifactId>
-  <version>2.9.8</version>
+  <version>2.9.9</version>
 </dependency>
 ----
 


### PR DESCRIPTION
Bump the Maven coordinates of the dependencies in the README file as the current release setup does not do that automatically.