### PR TITLE
ci: Track released artifacts for EO 14028 compliance.

### DIFF
--- a/.kokoro/stage.cfg
+++ b/.kokoro/stage.cfg
@@ -1,3 +1,12 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
 build_file: "google-cloud-spanner-hibernate/.kokoro/stage.sh"
+
+# Save artifacts for EO 14028
+action {
+  define_artifacts {
+    regex: "**/target/*.pom"
+    regex: "**/target/*.jar"
+  }
+}
+


### PR DESCRIPTION
This updates the stage job to record the build artifacts so that Kokoro can generate
an SBOM.