### PR TITLE
fix: add default configuration for license header lint.

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -1,0 +1,11 @@
+allowedCopyrightHolders:
+- 'Google LLC'
+allowedLicenses:
+- 'Apache-2.0'
+- 'MIT'
+- 'BSD-3'
+sourceFileExtensions:
+- 'ts'
+- 'js'
+- 'java'
+# ignoreFiles are empty


### PR DESCRIPTION
Add the default config for setting up `header-check` . Currently it's failing in few PRs - https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate/pull/596/checks?check_run_id=15195254300