### PR TITLE
test: add mock server tests for schema generation

### DIFF
--- a/checkstyle/checkstyle-suppressions.xml
+++ b/checkstyle/checkstyle-suppressions.xml
@@ -6,4 +6,6 @@
 <suppressions>
   <suppress checks="AbbreviationAsWordInName" files=".*IT.java" />
   <suppress checks="MissingJavadocType" files="[\\/]google-cloud-spanner-hibernate-samples[\\/]" />
+  <!--Ignore long lines in mock server tests, as these use a lot of mocked SQL that can be very long, and that is easier to read if it is formatted in its original form. -->
+  <suppress checks="LineLength" files=".*MockServerTest.java" />
 </suppressions>

--- a/google-cloud-spanner-hibernate-dialect/pom.xml
+++ b/google-cloud-spanner-hibernate-dialect/pom.xml
@@ -10,6 +10,7 @@
 
   <properties>
     <apache.lang.version>3.13.0</apache.lang.version>
+    <spanner.version>6.44.0</spanner.version>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>
@@ -39,14 +40,14 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>6.37.0</version>
+      <version>${spanner.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
-      <version>2.31.1</version>
+      <version>2.18.2</version>
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/AbstractMockSpannerServerTest.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/AbstractMockSpannerServerTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019-2023 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.MockSpannerServiceImpl;
+import com.google.cloud.spanner.admin.database.v1.MockDatabaseAdminImpl;
+import com.google.cloud.spanner.connection.SpannerPool;
+import com.google.common.collect.ImmutableMap;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
+import com.google.protobuf.Empty;
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
+import com.google.spanner.v1.SpannerGrpc;
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.hibernate.cfg.Configuration;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/** Abstract base class for Hibernate tests using an in-mem mock Spanner server. */
+public abstract class AbstractMockSpannerServerTest {
+  protected static MockSpannerServiceImpl mockSpanner;
+  protected static MockDatabaseAdminImpl mockDatabaseAdmin;
+  private static Server server;
+
+  /** Setup in-memory mock Spanner server. */
+  @BeforeClass
+  public static void setup() throws IOException {
+    mockSpanner = new MockSpannerServiceImpl();
+    mockSpanner.setAbortProbability(0.0D); // We don't want any unpredictable aborted transactions.
+    mockDatabaseAdmin = new MockDatabaseAdminImpl();
+    InetSocketAddress address = new InetSocketAddress("localhost", 0);
+    server =
+        NettyServerBuilder.forAddress(address)
+            .addService(mockSpanner)
+            .addService(mockDatabaseAdmin)
+            .intercept(
+                new ServerInterceptor() {
+                  @Override
+                  public <ReqT, RespT> Listener<ReqT> interceptCall(
+                      ServerCall<ReqT, RespT> serverCall,
+                      Metadata metadata,
+                      ServerCallHandler<ReqT, RespT> serverCallHandler) {
+
+                    if (SpannerGrpc.getExecuteStreamingSqlMethod()
+                        .getFullMethodName()
+                        .equals(serverCall.getMethodDescriptor().getFullMethodName())) {
+                      String userAgent =
+                          metadata.get(
+                              Metadata.Key.of(
+                                  "x-goog-api-client", Metadata.ASCII_STRING_MARSHALLER));
+                      assertNotNull(userAgent);
+                      assertTrue(userAgent.contains("sp-hib"));
+                    }
+                    return Contexts.interceptCall(
+                        Context.current(), serverCall, metadata, serverCallHandler);
+                  }
+                })
+            .build()
+            .start();
+  }
+
+  /** Stop and cleanup mock Spanner server. */
+  @AfterClass
+  public static void teardown() throws InterruptedException {
+    SpannerPool.closeSpannerPool();
+    server.shutdown();
+    server.awaitTermination();
+  }
+
+  @After
+  public void clearRequests() {
+    mockSpanner.clearRequests();
+    mockDatabaseAdmin.reset();
+  }
+
+  protected void addDdlResponseToSpannerAdmin() {
+    mockDatabaseAdmin.addResponse(
+        Operation.newBuilder()
+            .setDone(true)
+            .setResponse(Any.pack(Empty.getDefaultInstance()))
+            .setMetadata(Any.pack(UpdateDatabaseDdlMetadata.getDefaultInstance()))
+            .build());
+  }
+
+  protected void addDdlExceptionToSpannerAdmin() {
+    mockDatabaseAdmin.addException(
+        Status.INVALID_ARGUMENT.withDescription("Statement is invalid.").asRuntimeException());
+  }
+
+  protected String createTestJdbcUrl() {
+    return String.format(
+        "jdbc:cloudspanner://localhost:%d/projects/my-project/instances/my-instance"
+            + "/databases/my-database?usePlainText=true",
+        server.getPort());
+  }
+
+  protected Configuration createTestHibernateConfig(Iterable<Class<?>> entityClasses) {
+    return createTestHibernateConfig(entityClasses, ImmutableMap.of());
+  }
+
+  protected Configuration createTestHibernateConfig(
+      Iterable<Class<?>> entityClasses, Map<String, String> hibernateProperties) {
+    Configuration config = new Configuration();
+
+    config.setProperty(
+        "hibernate.connection.driver_class", "com.google.cloud.spanner.jdbc.JdbcDriver");
+    config.setProperty("hibernate.connection.url", createTestJdbcUrl());
+    config.setProperty("hibernate.dialect", "com.google.cloud.spanner.hibernate.SpannerDialect");
+    for (Entry<String, String> property : hibernateProperties.entrySet()) {
+      config.setProperty(property.getKey(), property.getValue());
+    }
+    for (Class<?> entityClass : entityClasses) {
+      config.addAnnotatedClass(entityClass);
+    }
+
+    return config;
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SchemaGenerationMockServerTest.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SchemaGenerationMockServerTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2019-2023 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.hibernate.entities.Account;
+import com.google.cloud.spanner.hibernate.entities.Airplane;
+import com.google.cloud.spanner.hibernate.entities.Airport;
+import com.google.cloud.spanner.hibernate.entities.Child;
+import com.google.cloud.spanner.hibernate.entities.Customer;
+import com.google.cloud.spanner.hibernate.entities.Employee;
+import com.google.cloud.spanner.hibernate.entities.GrandParent;
+import com.google.cloud.spanner.hibernate.entities.Invoice;
+import com.google.cloud.spanner.hibernate.entities.Parent;
+import com.google.cloud.spanner.hibernate.entities.Singer;
+import com.google.cloud.spanner.hibernate.entities.SubTestEntity;
+import com.google.cloud.spanner.hibernate.entities.TestEntity;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest;
+import com.google.spanner.v1.ResultSet;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.StructType;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hibernate.SessionFactory;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Verifies that the correct database schema is being generated, and that the schema generation uses
+ * a DDL batch.
+ */
+public class SchemaGenerationMockServerTest extends AbstractMockSpannerServerTest {
+
+  /** Set up empty mocked results for schema queries. */
+  @BeforeClass
+  public static void setupSchemaQueryResults() {
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.newBuilder(
+                    "SELECT TABLE_CATALOG AS TABLE_CAT, TABLE_SCHEMA AS TABLE_SCHEM, TABLE_NAME,\n"
+                        + "       CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END AS TABLE_TYPE,\n"
+                        + "       NULL AS REMARKS, NULL AS TYPE_CAT, NULL AS TYPE_SCHEM, NULL AS TYPE_NAME,\n"
+                        + "       NULL AS SELF_REFERENCING_COL_NAME, NULL AS REF_GENERATION\n"
+                        + "FROM INFORMATION_SCHEMA.TABLES AS T\n"
+                        + "WHERE UPPER(TABLE_CATALOG) LIKE @p1\n"
+                        + "  AND UPPER(TABLE_SCHEMA) LIKE @p2\n"
+                        + "  AND UPPER(TABLE_NAME) LIKE @p3\n"
+                        + "  AND (\n"
+                        + "            (CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) LIKE @p4\n"
+                        + "        OR\n"
+                        + "            (CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) LIKE @p5\n"
+                        + "    )\n"
+                        + "ORDER BY TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME")
+                .bind("p1")
+                .to("%")
+                .bind("p2")
+                .to("%")
+                .bind("p3")
+                .to("%")
+                .bind("p4")
+                .to("TABLE")
+                .bind("p5")
+                .to("VIEW")
+                .build(),
+            ResultSet.newBuilder()
+                .setMetadata(
+                    ResultSetMetadata.newBuilder()
+                        .setRowType(StructType.newBuilder().build())
+                        .build())
+                .build()));
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.newBuilder(
+                    "SELECT IDX.TABLE_CATALOG AS TABLE_CAT, IDX.TABLE_SCHEMA AS TABLE_SCHEM, IDX.TABLE_NAME,\n"
+                        + "  CASE WHEN IS_UNIQUE THEN FALSE ELSE TRUE END AS NON_UNIQUE,\n"
+                        + "  IDX.TABLE_CATALOG AS INDEX_QUALIFIER, IDX.INDEX_NAME,\n"
+                        + "  CASE WHEN IDX.INDEX_NAME = 'PRIMARY_KEY' THEN 1 ELSE 2 END AS TYPE,\n"
+                        + "  ORDINAL_POSITION, COLUMN_NAME, SUBSTR(COLUMN_ORDERING, 1, 1) AS ASC_OR_DESC,\n"
+                        + "  -1 AS CARDINALITY, \n"
+                        + "  -1 AS PAGES, \n"
+                        + "  NULL AS FILTER_CONDITION\n"
+                        + "FROM INFORMATION_SCHEMA.INDEXES IDX\n"
+                        + "INNER JOIN INFORMATION_SCHEMA.INDEX_COLUMNS COL\n"
+                        + "  ON  IDX.TABLE_CATALOG=COL.TABLE_CATALOG\n"
+                        + "  AND IDX.TABLE_SCHEMA=COL.TABLE_SCHEMA\n"
+                        + "  AND IDX.TABLE_NAME=COL.TABLE_NAME\n"
+                        + "  AND IDX.INDEX_NAME=COL.INDEX_NAME\n"
+                        + "WHERE UPPER(IDX.TABLE_CATALOG) LIKE @p1\n"
+                        + "  AND UPPER(IDX.TABLE_SCHEMA) LIKE @p2\n"
+                        + "  AND UPPER(IDX.TABLE_NAME) LIKE @p3\n"
+                        + "  AND UPPER(IDX.INDEX_NAME) LIKE @p4\n"
+                        + "  AND (CASE WHEN IS_UNIQUE THEN 'YES' ELSE 'NO' END) LIKE @p5\n"
+                        + "ORDER BY IDX.TABLE_NAME, IS_UNIQUE DESC, IDX.INDEX_NAME, CASE WHEN ORDINAL_POSITION IS NULL THEN 0 ELSE ORDINAL_POSITION END")
+                .bind("p1")
+                .to("%")
+                .bind("p2")
+                .to("%")
+                .bind("p3")
+                .to("%")
+                .bind("p4")
+                .to("%")
+                .bind("p5")
+                .to("%")
+                .build(),
+            ResultSet.newBuilder()
+                .setMetadata(
+                    ResultSetMetadata.newBuilder()
+                        .setRowType(StructType.newBuilder().build())
+                        .build())
+                .build()));
+  }
+
+  @Test
+  public void testGenerateSchema() {
+    addDdlResponseToSpannerAdmin();
+
+    //noinspection EmptyTryBlock
+    try (SessionFactory ignore =
+        createTestHibernateConfig(
+                ImmutableList.of(Singer.class, Invoice.class, Customer.class, Account.class),
+                ImmutableMap.of("hibernate.hbm2ddl.auto", "create-only"))
+            .buildSessionFactory()) {
+      // do nothing, just generate the schema.
+    }
+
+    // Check the DDL statements that were generated.
+    List<UpdateDatabaseDdlRequest> requests =
+        mockDatabaseAdmin.getRequests().stream()
+            .filter(request -> request instanceof UpdateDatabaseDdlRequest)
+            .map(request -> (UpdateDatabaseDdlRequest) request)
+            .collect(Collectors.toList());
+    assertEquals(1, requests.size());
+    UpdateDatabaseDdlRequest request = requests.get(0);
+    assertEquals(8, request.getStatementsCount());
+
+    int index = -1;
+
+    assertEquals(
+        "create table Account (id INT64 not null,amount NUMERIC,name STRING(255)) PRIMARY KEY (id)",
+        request.getStatements(++index));
+    assertEquals(
+        "create table Customer (customerId INT64 not null,name STRING(255)) PRIMARY KEY (customerId)",
+        request.getStatements(++index));
+    assertEquals(
+        "create table customerId (next_val INT64) PRIMARY KEY ()", request.getStatements(++index));
+    assertEquals(
+        "create table Invoice (invoiceId INT64 not null,number STRING(255),customer_customerId INT64) PRIMARY KEY (invoiceId)",
+        request.getStatements(++index));
+    assertEquals(
+        "create table invoiceId (next_val INT64) PRIMARY KEY ()", request.getStatements(++index));
+    assertEquals(
+        "create table Singer (id INT64 not null) PRIMARY KEY (id)", request.getStatements(++index));
+    assertEquals(
+        "create table singerId (next_val INT64) PRIMARY KEY ()", request.getStatements(++index));
+    assertEquals(
+        "alter table Invoice add constraint fk_invoice_customer foreign key (customer_customerId) references Customer (customerId) on delete cascade",
+        request.getStatements(++index));
+  }
+
+  @Test
+  public void testGenerateEmployeeSchema() {
+    addDdlResponseToSpannerAdmin();
+
+    //noinspection EmptyTryBlock
+    try (SessionFactory ignore =
+        createTestHibernateConfig(
+                ImmutableList.of(Employee.class),
+                ImmutableMap.of("hibernate.hbm2ddl.auto", "create-only"))
+            .buildSessionFactory()) {
+      // do nothing, just generate the schema.
+    }
+
+    // Check the DDL statements that were generated.
+    List<UpdateDatabaseDdlRequest> requests =
+        mockDatabaseAdmin.getRequests().stream()
+            .filter(request -> request instanceof UpdateDatabaseDdlRequest)
+            .map(request -> (UpdateDatabaseDdlRequest) request)
+            .collect(Collectors.toList());
+    assertEquals(1, requests.size());
+    UpdateDatabaseDdlRequest request = requests.get(0);
+    assertEquals(4, request.getStatementsCount());
+
+    int index = -1;
+
+    assertEquals(
+        "create table Employee (id INT64 not null,name STRING(255),manager_id INT64) PRIMARY KEY (id)",
+        request.getStatements(++index));
+    assertEquals(
+        "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
+        request.getStatements(++index));
+    assertEquals("create index name_index on Employee (name)", request.getStatements(++index));
+    assertEquals(
+        "alter table Employee add constraint FKiralam2duuhr33k8a10aoc2t6 foreign key (manager_id) references Employee (id)",
+        request.getStatements(++index));
+  }
+
+  @Test
+  public void testGenerateAirportSchema() {
+    addDdlResponseToSpannerAdmin();
+
+    //noinspection EmptyTryBlock
+    try (SessionFactory ignore =
+        createTestHibernateConfig(
+                ImmutableList.of(Airplane.class, Airport.class),
+                ImmutableMap.of("hibernate.hbm2ddl.auto", "create-only"))
+            .buildSessionFactory()) {
+      // do nothing, just generate the schema.
+    }
+
+    // Check the DDL statements that were generated.
+    List<UpdateDatabaseDdlRequest> requests =
+        mockDatabaseAdmin.getRequests().stream()
+            .filter(request -> request instanceof UpdateDatabaseDdlRequest)
+            .map(request -> (UpdateDatabaseDdlRequest) request)
+            .collect(Collectors.toList());
+    assertEquals(1, requests.size());
+    UpdateDatabaseDdlRequest request = requests.get(0);
+    assertEquals(7, request.getStatementsCount());
+
+    int index = -1;
+
+    assertEquals(
+        "create table Airplane (id STRING(255) not null,modelName STRING(255)) PRIMARY KEY (id)",
+        request.getStatements(++index));
+    assertEquals(
+        "create table Airport (id STRING(255) not null) PRIMARY KEY (id)",
+        request.getStatements(++index));
+    assertEquals(
+        "create table Airport_Airplane (Airport_id STRING(255) not null,airplanes_id STRING(255) not null) PRIMARY KEY (Airport_id,airplanes_id)",
+        request.getStatements(++index));
+
+    assertEquals(
+        "create unique index UK_gc568wb30sampsuirwne5jqgh on Airplane (modelName)",
+        request.getStatements(++index));
+    assertEquals(
+        "create unique index UK_em0lqvwoqdwt29x0b0r010be on Airport_Airplane (airplanes_id)",
+        request.getStatements(++index));
+    assertEquals(
+        "alter table Airport_Airplane add constraint FKkn0enwaxbwk7csf52x0eps73d foreign key (airplanes_id) references Airplane (id)",
+        request.getStatements(++index));
+    assertEquals(
+        "alter table Airport_Airplane add constraint FKh186t28ublke8o13fo4ppogs7 foreign key (Airport_id) references Airport (id)",
+        request.getStatements(++index));
+  }
+
+  @Test
+  public void testGenerateParentChildSchema() {
+    addDdlResponseToSpannerAdmin();
+
+    //noinspection EmptyTryBlock
+    try (SessionFactory ignore =
+        createTestHibernateConfig(
+                ImmutableList.of(GrandParent.class, Parent.class, Child.class),
+                ImmutableMap.of("hibernate.hbm2ddl.auto", "create-only"))
+            .buildSessionFactory()) {
+      // do nothing, just generate the schema.
+    }
+
+    // Check the DDL statements that were generated.
+    List<UpdateDatabaseDdlRequest> requests =
+        mockDatabaseAdmin.getRequests().stream()
+            .filter(request -> request instanceof UpdateDatabaseDdlRequest)
+            .map(request -> (UpdateDatabaseDdlRequest) request)
+            .collect(Collectors.toList());
+    assertEquals(1, requests.size());
+    UpdateDatabaseDdlRequest request = requests.get(0);
+    assertEquals(4, request.getStatementsCount());
+
+    int index = -1;
+
+    assertEquals(
+        "create table GrandParent (grandParentId INT64 not null,name STRING(255)) PRIMARY KEY (grandParentId)",
+        request.getStatements(++index));
+    assertEquals(
+        "create table Parent (grandParentId INT64 not null,parentId INT64 not null,name STRING(255)) "
+            + "PRIMARY KEY (grandParentId,parentId), INTERLEAVE IN PARENT GrandParent",
+        request.getStatements(++index));
+    assertEquals(
+        "create table Child (childId INT64 not null,grandParentId INT64 not null,parentId INT64 not null,name STRING(255)) "
+            + "PRIMARY KEY (grandParentId,parentId,childId), INTERLEAVE IN PARENT Parent",
+        request.getStatements(++index));
+    assertEquals(
+        "create table hibernate_sequence (next_val INT64) PRIMARY KEY ()",
+        request.getStatements(++index));
+  }
+
+  @Test
+  public void testGenerateTestEntitySchema() {
+    addDdlResponseToSpannerAdmin();
+
+    //noinspection EmptyTryBlock
+    try (SessionFactory ignore =
+        createTestHibernateConfig(
+                ImmutableList.of(TestEntity.class, SubTestEntity.class),
+                ImmutableMap.of("hibernate.hbm2ddl.auto", "create-only"))
+            .buildSessionFactory()) {
+      // do nothing, just generate the schema.
+    }
+
+    // Check the DDL statements that were generated.
+    List<UpdateDatabaseDdlRequest> requests =
+        mockDatabaseAdmin.getRequests().stream()
+            .filter(request -> request instanceof UpdateDatabaseDdlRequest)
+            .map(request -> (UpdateDatabaseDdlRequest) request)
+            .collect(Collectors.toList());
+    assertEquals(1, requests.size());
+    UpdateDatabaseDdlRequest request = requests.get(0);
+    assertEquals(5, request.getStatementsCount());
+
+    int index = -1;
+
+    assertEquals(
+        "create table `TestEntity_stringList` ("
+            + "`TestEntity_ID1` INT64 not null,"
+            + "`TestEntity_id2` STRING(255) not null,"
+            + "stringList STRING(255)) "
+            + "PRIMARY KEY (`TestEntity_ID1`,`TestEntity_id2`,stringList)",
+        request.getStatements(++index));
+    assertEquals(
+        "create table SubTestEntity (id STRING(255) not null,id1 INT64,id2 STRING(255)) PRIMARY KEY (id)",
+        request.getStatements(++index));
+    assertEquals(
+        "create table `test_table` ("
+            + "`ID1` INT64 not null,id2 STRING(255) not null,"
+            + "`boolColumn` BOOL,"
+            + "longVal INT64 not null,"
+            + "stringVal STRING(255)) "
+            + "PRIMARY KEY (`ID1`,id2)",
+        request.getStatements(++index));
+    assertEquals(
+        "alter table `TestEntity_stringList` add constraint FK2is6fwy3079dmfhjot09x5och "
+            + "foreign key (`TestEntity_ID1`, `TestEntity_id2`) references `test_table` (`ID1`, id2)",
+        request.getStatements(++index));
+    assertEquals(
+        "alter table SubTestEntity add constraint FK45l9js1jvci3yy21exuclnku0 "
+            + "foreign key (id1, id2) references `test_table` (`ID1`, id2)",
+        request.getStatements(++index));
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/entities/Invoice.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/entities/Invoice.java
@@ -27,6 +27,8 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.id.enhanced.SequenceStyleGenerator;
 
@@ -54,6 +56,7 @@ public class Invoice {
 
   @ManyToOne
   @JoinColumn(foreignKey = @ForeignKey(name = "fk_invoice_customer"))
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Customer customer;
 
 }


### PR DESCRIPTION
Refactors the current mock server test into an abstract base class and a concrete class, and adds a new test that verifies that schema generation works as intended. This in preparation of adding a Hibernate 6.x dialect to the repository.