### PR TITLE
build: disable license header check as LGPL cannot be configured

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -4,6 +4,7 @@ allowedLicenses:
 - 'Apache-2.0'
 - 'MIT'
 - 'BSD-3'
+- 'LGPL'
 sourceFileExtensions:
 - 'ts'
 - 'js'

--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -4,9 +4,6 @@ allowedLicenses:
 - 'Apache-2.0'
 - 'MIT'
 - 'BSD-3'
-- 'LGPL'
+# Deliberately empty to disable the check.
 sourceFileExtensions:
-- 'ts'
-- 'js'
-- 'java'
 # ignoreFiles are empty

--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -5,5 +5,5 @@ allowedLicenses:
 - 'MIT'
 - 'BSD-3'
 # Deliberately empty to disable the check.
-sourceFileExtensions:
+sourceFileExtensions: []
 # ignoreFiles are empty


### PR DESCRIPTION
The License header check does not support LGPL as a possible license: https://github.com/googleapis/repo-automation-bots/tree/main/packages/header-checker-lint

The entire check is however superfluous, as we already have a check for this header: https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate/blob/master/checkstyle/java.header