### PR TITLE
fix: JDBC connection was leaked during schema creation

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerExtractionContext.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerExtractionContext.java
@@ -77,7 +77,7 @@ public class SpannerExtractionContext extends ImprovedExtractionContextImpl {
     super.cleanup();
     if (extractionConnection != null) {
       try {
-        extractionConnection.close();
+        jdbcConnectionAccess.releaseConnection(extractionConnection);
       } catch (SQLException exception) {
         log.warn(
             "An exception was thrown while closing the JDBC connection "

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaManagementTool.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaManagementTool.java
@@ -31,7 +31,9 @@ import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
@@ -52,6 +54,7 @@ import org.hibernate.tool.schema.spi.SchemaMigrator;
  * DDL statements.
  */
 public class SpannerSchemaManagementTool extends HibernateSchemaManagementTool {
+
   /**
    * Custom implementation for {@link DdlTransactionIsolator} that will automatically create a proxy
    * for Connection and Statement. These proxies will again be used to override the default behavior
@@ -65,14 +68,28 @@ public class SpannerSchemaManagementTool extends HibernateSchemaManagementTool {
    * cause an error to be returned for the migration.
    */
   static class SpannerDdlTransactionIsolator implements DdlTransactionIsolator {
+
     private static final AbstractStatementParser PARSER =
         AbstractStatementParser.getInstance(Dialect.GOOGLE_STANDARD_SQL);
+
+    /**
+     * A set containing all connections that have been obtained by this
+     * {@link DdlTransactionIsolator}. We use a {@link Set}, because the connection is obtained from
+     * the {@link DdlTransactionIsolator} that is configured for this environment, and some
+     * implementations
+     * ({@link
+     * org.hibernate.resource.transaction.backend.jta.internal.DdlTransactionIsolatorJtaImpl})
+     * return the same connection each time, and we only want to release it once.
+     */
+    private final Set<Connection> obtainedConnections = new HashSet<>();
+    private final Method connectionCloseMethod;
     private final Method createStatementMethod;
     private final Method executeMethod;
     private final DdlTransactionIsolator delegate;
 
     SpannerDdlTransactionIsolator(DdlTransactionIsolator delegate) throws NoSuchMethodException {
       this.delegate = delegate;
+      this.connectionCloseMethod = Connection.class.getDeclaredMethod("close");
       this.createStatementMethod = Connection.class.getDeclaredMethod("createStatement");
       this.executeMethod = Statement.class.getDeclaredMethod("execute", String.class);
     }
@@ -90,12 +107,15 @@ public class SpannerSchemaManagementTool extends HibernateSchemaManagementTool {
     @Override
     public Connection getIsolatedConnection() {
       Connection delegateConnection = this.delegate.getIsolatedConnection();
+      // Add the delegate connection to the set of obtained connections so we can release these
+      // when the DdlTransactionIsolator is released.
+      obtainedConnections.add(delegateConnection);
       // Create a proxy for the connection that will override the call to
       // Connection#createStatement().
       return (Connection)
           Proxy.newProxyInstance(
               delegateConnection.getClass().getClassLoader(),
-              new Class[] {Connection.class},
+              new Class[]{Connection.class},
               (proxy, method, args) -> {
                 // Only handle the Connection#createStatement() differently.
                 // All other methods are just passed through.
@@ -103,6 +123,10 @@ public class SpannerSchemaManagementTool extends HibernateSchemaManagementTool {
                   // Create a proxy for the returned Statement that will override the behavior of
                   // Statement#execute(String).
                   return createProxyStatement(delegateConnection);
+                } else if (method.equals(connectionCloseMethod)) {
+                  // Ignore as the connection is released when this DdlTransactionIsolator is
+                  // released.
+                  return null;
                 }
                 try {
                   return method.invoke(delegateConnection, args);
@@ -113,16 +137,16 @@ public class SpannerSchemaManagementTool extends HibernateSchemaManagementTool {
     }
 
     /**
-     * Creates a proxy for a {@link Statement} that will throw a {@link
-     * com.google.cloud.spanner.SpannerException} instead of a {@link SQLException} if a `START
-     * BATCH DDL` or `RUN BATCH` statement fails.
+     * Creates a proxy for a {@link Statement} that will throw a
+     * {@link com.google.cloud.spanner.SpannerException} instead of a {@link SQLException} if a
+     * `START BATCH DDL` or `RUN BATCH` statement fails.
      */
     private Statement createProxyStatement(Connection delegateConnection) throws SQLException {
       Statement delegateStatement = delegateConnection.createStatement();
       return (Statement)
           Proxy.newProxyInstance(
               delegateConnection.getClass().getClassLoader(),
-              new Class[] {Statement.class},
+              new Class[]{Statement.class},
               (proxy1, method1, args1) -> {
                 // Only handle the Statement#execute(String) method differently.
                 // All other methods are just passed through.
@@ -137,9 +161,9 @@ public class SpannerSchemaManagementTool extends HibernateSchemaManagementTool {
                       PARSER.parse(com.google.cloud.spanner.Statement.of(sql));
                   if (statement.getType() == StatementType.CLIENT_SIDE
                       && (statement.getClientSideStatementType()
-                              == ClientSideStatementType.START_BATCH_DDL
-                          || statement.getClientSideStatementType()
-                              == ClientSideStatementType.RUN_BATCH)) {
+                      == ClientSideStatementType.START_BATCH_DDL
+                      || statement.getClientSideStatementType()
+                      == ClientSideStatementType.RUN_BATCH)) {
                     try {
                       // Try to execute the statement, and convert any SQLException to a
                       // SpannerException.
@@ -163,6 +187,13 @@ public class SpannerSchemaManagementTool extends HibernateSchemaManagementTool {
 
     @Override
     public void release() {
+      for (Connection connection : obtainedConnections) {
+        try {
+          getJdbcContext().getJdbcConnectionAccess().releaseConnection(connection);
+        } catch (SQLException ignore) {
+          // Ignore any errors when releasing a connection and continue with the next.
+        }
+      }
       delegate.release();
     }
   }
@@ -206,7 +237,8 @@ public class SpannerSchemaManagementTool extends HibernateSchemaManagementTool {
 
     private static final SpannerExtractionTool INSTANCE = new SpannerExtractionTool();
 
-    private SpannerExtractionTool() {}
+    private SpannerExtractionTool() {
+    }
 
     @Override
     public ExtractionContext createExtractionContext(

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/schema/SpannerExtractionContextTest.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/schema/SpannerExtractionContextTest.java
@@ -83,7 +83,7 @@ public class SpannerExtractionContextTest {
   }
 
   @Test
-  public void testCleanupClosesConnection() throws SQLException {
+  public void testCleanupReleasesConnection() throws SQLException {
     DdlTransactionIsolator ddlTransactionIsolator = mock(DdlTransactionIsolator.class);
     JdbcContext jdbcContext = mock(JdbcContext.class);
     JdbcConnectionAccess jdbcConnectionAccess = mock(JdbcConnectionAccess.class);
@@ -104,7 +104,7 @@ public class SpannerExtractionContextTest {
     context.getJdbcConnection();
     context.cleanup();
 
-    verify(connection).close();
+    verify(jdbcConnectionAccess).releaseConnection(connection);
   }
 
   @Test
@@ -140,7 +140,7 @@ public class SpannerExtractionContextTest {
     when(ddlTransactionIsolator.getJdbcContext()).thenReturn(jdbcContext);
     when(jdbcContext.getJdbcConnectionAccess()).thenReturn(jdbcConnectionAccess);
     when(jdbcConnectionAccess.obtainConnection()).thenReturn(connection);
-    doThrow(new SQLException("test")).when(connection).close();
+    doThrow(new SQLException("test")).when(jdbcConnectionAccess).releaseConnection(connection);
     SpannerExtractionContext context =
         new SpannerExtractionContext(
             mock(ServiceRegistry.class),
@@ -152,6 +152,6 @@ public class SpannerExtractionContextTest {
     context.getJdbcConnection();
     // Cleanup should ignore any errors.
     context.cleanup();
-    verify(connection).close();
+    verify(jdbcConnectionAccess).releaseConnection(connection);
   }
 }


### PR DESCRIPTION
Fixes a JDBC connection leak during schema creation. The schema creation process would obtain an isolated JDBC connection from the pool to extract metadata. This connection was not released back into the pool when the DdlTransactionIsolator was released.