### PR TITLE
chore: remove double return of connections

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaCreator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaCreator.java
@@ -21,6 +21,7 @@ package com.google.cloud.spanner.hibernate.schema;
 import java.sql.Connection;
 import java.sql.SQLException;
 import org.hibernate.boot.Metadata;
+import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.tool.schema.Action;
 import org.hibernate.tool.schema.internal.SchemaCreatorImpl;
 import org.hibernate.tool.schema.spi.ExecutionOptions;
@@ -53,13 +54,17 @@ public class SpannerSchemaCreator implements SchemaCreator {
     metadata.getDatabase().addAuxiliaryDatabaseObject(new StartBatchDdl(Action.CREATE));
     metadata.getDatabase().addAuxiliaryDatabaseObject(new RunBatchDdl(Action.CREATE));
 
-    try (Connection connection = tool.getDatabaseMetadataConnection(options)) {
+    DdlTransactionIsolator isolator = tool.getDdlTransactionIsolator(options);
+    try {
+      Connection connection = isolator.getIsolatedConnection();
       SpannerDatabaseInfo spannerDatabaseInfo = new SpannerDatabaseInfo(connection.getMetaData());
       tool.getSpannerTableExporter(options).init(metadata, spannerDatabaseInfo, Action.CREATE);
       tool.getForeignKeyExporter(options).init(spannerDatabaseInfo);
       schemaCreator.doCreation(metadata, options, sourceDescriptor, targetDescriptor);
     } catch (SQLException e) {
       throw new RuntimeException("Failed to update Spanner table schema.", e);
+    } finally {
+      isolator.release();
     }
   }
 }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaMigrator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaMigrator.java
@@ -21,6 +21,7 @@ package com.google.cloud.spanner.hibernate.schema;
 import java.sql.Connection;
 import java.sql.SQLException;
 import org.hibernate.boot.Metadata;
+import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.tool.schema.Action;
 import org.hibernate.tool.schema.spi.ExecutionOptions;
 import org.hibernate.tool.schema.spi.SchemaMigrator;
@@ -50,13 +51,17 @@ public class SpannerSchemaMigrator implements SchemaMigrator {
     metadata.getDatabase().addAuxiliaryDatabaseObject(new StartBatchDdl(Action.UPDATE));
     metadata.getDatabase().addAuxiliaryDatabaseObject(new RunBatchDdl(Action.UPDATE));
 
-    try (Connection connection = tool.getDatabaseMetadataConnection(options)) {
+    DdlTransactionIsolator isolator = tool.getDdlTransactionIsolator(options);
+    try {
+      Connection connection = isolator.getIsolatedConnection();
       SpannerDatabaseInfo spannerDatabaseInfo = new SpannerDatabaseInfo(connection.getMetaData());
       tool.getSpannerTableExporter(options).init(metadata, spannerDatabaseInfo, Action.UPDATE);
       tool.getForeignKeyExporter(options).init(spannerDatabaseInfo);
       schemaMigrator.doMigration(metadata, options, targetDescriptor);
     } catch (SQLException e) {
       throw new RuntimeException("Failed to update Spanner table schema.", e);
+    } finally {
+      isolator.release();
     }
   }
 }


### PR DESCRIPTION
Fix the double return of the same connections to the pool. This was introduced by #738 