### PR TITLE
fix: update version numbers in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,6 +6,8 @@
 This is a dialect compatible with https://hibernate.org/orm/releases/6.3/[Hibernate 6.3] for the https://cloud.google.com/spanner/[Google Cloud Spanner] database service.
 The `SpannerDialect` produces SQL, DML, and DDL statements for most common entity types and relationships using standard Hibernate and Java Persistence annotations.
 
+Version 1.x and 2.x of this library supports Hibernate 5.4.
+
 Please see the following sections for important details about dialect differences due to the unique features and limitations of Cloud Spanner.
 
 == Quick Set-Up
@@ -19,7 +21,7 @@ Maven coordinates for the dialect:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-hibernate-dialect</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.3</version>
 </dependency>
 ----
 
@@ -30,7 +32,7 @@ Maven coordinates for the official https://cloud.google.com/spanner/docs/open-so
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-jdbc</artifactId>
-  <version>2.14.2</version>
+  <version>2.14.4</version>
 </dependency>
 ----
 


### PR DESCRIPTION
- Update the version numbers in the README file
- Clarify which versions can be used with Hibernate 5.4

BEGIN_COMMIT_OVERRIDE
deps: requires Hibernate 6.3

Version 3.0.x of this library requires __Hibernate 6.3__.
This version is not compatible with Hibernate 5.4. You should use version 2.x
of this library if you want to continue working with Hibernate 5.4.

Version 3.0.0 was not successfully pushed to Maven Central, which is why
these release notes repeats the message regarding the upgrade to Hibernate 6.3.

See https://docs.jboss.org/hibernate/orm/6.0/migration-guide/migration-guide.html
for a guide for upgrading from Hibernate 5 to Hibernate 6.

END_COMMIT_OVERRIDE