### PR TITLE
feat: prepare for named schemas

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerUniqueDelegate.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerUniqueDelegate.java
@@ -18,6 +18,7 @@
 
 package com.google.cloud.spanner.hibernate;
 
+import com.google.common.base.Strings;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
@@ -52,6 +53,9 @@ public class SpannerUniqueDelegate extends DefaultUniqueDelegate {
   public String getAlterTableToDropUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata,
       SqlStringGenerationContext context) {
     StringBuilder buf = new StringBuilder("DROP INDEX ");
+    if (!Strings.isNullOrEmpty(uniqueKey.getTable().getSchema())) {
+      buf.append(dialect.quote(uniqueKey.getTable().getSchema())).append('.');
+    }
     buf.append(dialect.quote(uniqueKey.getName()));
     return buf.toString();
   }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerDatabaseInfo.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerDatabaseInfo.java
@@ -21,52 +21,59 @@ package com.google.cloud.spanner.hibernate.schema;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.Database;
+import org.hibernate.mapping.Table;
 
 /**
  * Helper class for extracting information from the {@link DatabaseMetaData} which contains
  * information about what tables and indices currently exist in the database.
  */
 public class SpannerDatabaseInfo {
+  
+  private final Set<Table> tableNames;
 
-  private final Set<String> tableNames;
-
-  private final Set<String> indexNames;
+  private final Map<Table, Set<String>> indexNames;
 
   private final DatabaseMetaData databaseMetaData;
 
   /**
    * Constructs the {@link SpannerDatabaseInfo} by querying the Spanner database metadata.
    */
-  public SpannerDatabaseInfo(DatabaseMetaData databaseMetaData) throws SQLException {
-    this.tableNames = extractDatabaseTables(databaseMetaData);
-    this.indexNames = extractDatabaseIndices(databaseMetaData);
+  public SpannerDatabaseInfo(Database database, DatabaseMetaData databaseMetaData)
+      throws SQLException {
+    this.tableNames = extractDatabaseTables(database, databaseMetaData);
+    this.indexNames = extractDatabaseIndices(database, databaseMetaData);
     this.databaseMetaData = databaseMetaData;
   }
 
   /**
    * Returns the table names in the Spanner database.
    */
-  public Set<String> getAllTables() {
+  public Set<Table> getAllTables() {
     return tableNames;
   }
 
   /**
    * Returns the names of all the indices in the Spanner database.
    */
-  public Set<String> getAllIndices() {
+  public Map<Table, Set<String>> getAllIndices() {
     return indexNames;
   }
 
   /**
    * Returns the names of all the imported foreign keys for a specified {@code tableName}.
    */
-  public Set<String> getImportedForeignKeys(String tableName) {
+  public Set<String> getImportedForeignKeys(Table table) {
     try {
       HashSet<String> foreignKeys = new HashSet<>();
 
-      ResultSet rs = databaseMetaData.getImportedKeys(null, null, tableName);
+      ResultSet rs = databaseMetaData.getImportedKeys(
+          table.getCatalog(), table.getSchema(), table.getName());
       while (rs.next()) {
         foreignKeys.add(rs.getString("FK_NAME"));
       }
@@ -74,40 +81,52 @@ public class SpannerDatabaseInfo {
       return foreignKeys;
     } catch (SQLException e) {
       throw new RuntimeException(
-          "Failed to lookup Spanner Database foreign keys for table: " + tableName, e);
+          "Failed to lookup Spanner Database foreign keys for table: " + table, e);
     }
   }
 
-  private static Set<String> extractDatabaseTables(DatabaseMetaData databaseMetaData)
-      throws SQLException {
-    HashSet<String> result = new HashSet<String>();
+  private static Set<Table> extractDatabaseTables(
+      Database database, DatabaseMetaData databaseMetaData) throws SQLException {
+    HashSet<Table> result = new HashSet<>();
 
     // Passing all null parameters will get all the tables and apply no filters.
-    ResultSet resultSet = databaseMetaData.getTables(
-        null, null, null, null);
-    while (resultSet.next()) {
-      String type = resultSet.getString("TABLE_TYPE");
-      if (type.equals("TABLE")) {
-        result.add(resultSet.getString("TABLE_NAME"));
+    try (ResultSet resultSet = databaseMetaData.getTables(
+        null, null, null, null)) {
+      while (resultSet.next()) {
+        String type = resultSet.getString("TABLE_TYPE");
+        if (type.equals("TABLE")) {
+          Table table = new Table("orm",
+              database.locateNamespace(
+                  Identifier.toIdentifier(resultSet.getString("TABLE_CAT")),
+                  Identifier.toIdentifier(resultSet.getString("TABLE_SCHEM"))),
+              Identifier.toIdentifier(resultSet.getString("TABLE_NAME")),
+              false);
+          result.add(table);
+        }
       }
     }
-    resultSet.close();
 
     return result;
   }
 
-  private static Set<String> extractDatabaseIndices(DatabaseMetaData databaseMetaData)
-      throws SQLException {
-    HashSet<String> result = new HashSet<>();
-    ResultSet indexResultSet = databaseMetaData.getIndexInfo(
-        null, null, null, false, false);
+  private static Map<Table, Set<String>> extractDatabaseIndices(
+      Database database, DatabaseMetaData databaseMetaData) throws SQLException {
+    HashMap<Table, Set<String>> result = new HashMap<>();
+    try (ResultSet indexResultSet = databaseMetaData.getIndexInfo(
+        null, null, null, false, false)) {
 
-    while (indexResultSet.next()) {
-      String name = indexResultSet.getString("INDEX_NAME");
-      result.add(name);
+      while (indexResultSet.next()) {
+        String name = indexResultSet.getString("INDEX_NAME");
+        Table table = new Table("orm",
+            database.locateNamespace(
+                Identifier.toIdentifier(indexResultSet.getString("TABLE_CAT")),
+                Identifier.toIdentifier(indexResultSet.getString("TABLE_SCHEM"))),
+            Identifier.toIdentifier(indexResultSet.getString("TABLE_NAME")),
+            false);
+        Set<String> tableIndices = result.computeIfAbsent(table, k -> new HashSet<>());
+        tableIndices.add(name);
+      }
     }
-    indexResultSet.close();
-
     return result;
   }
 }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerForeignKeyExporter.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerForeignKeyExporter.java
@@ -22,6 +22,7 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.mapping.ForeignKey;
+import org.hibernate.mapping.Table;
 import org.hibernate.tool.schema.internal.StandardForeignKeyExporter;
 
 /**
@@ -55,7 +56,7 @@ public class SpannerForeignKeyExporter extends StandardForeignKeyExporter {
   }
 
   private boolean foreignKeyExists(ForeignKey foreignKey) {
-    String table = foreignKey.getTable().getName();
+    Table table = foreignKey.getTable();
     return spannerDatabaseInfo.getAllTables().contains(table)
         && spannerDatabaseInfo.getImportedForeignKeys(table).contains(foreignKey.getName());
   }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaCreator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaCreator.java
@@ -59,7 +59,8 @@ public class SpannerSchemaCreator implements SchemaCreator {
     DdlTransactionIsolator isolator = tool.getDdlTransactionIsolator(options);
     try {
       Connection connection = isolator.getIsolatedConnection();
-      SpannerDatabaseInfo spannerDatabaseInfo = new SpannerDatabaseInfo(connection.getMetaData());
+      SpannerDatabaseInfo spannerDatabaseInfo =
+          new SpannerDatabaseInfo(metadata.getDatabase(), connection.getMetaData());
       tool.getSpannerTableExporter(options).init(metadata, spannerDatabaseInfo, Action.CREATE);
       tool.getForeignKeyExporter(options).init(spannerDatabaseInfo);
       schemaCreator.doCreation(

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaDropper.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaDropper.java
@@ -61,7 +61,8 @@ public class SpannerSchemaDropper implements SchemaDropper {
     try {
       Connection connection = isolator.getIsolatedConnection();
       // Initialize exporters with drop table dependencies so tables are dropped in the right order.
-      SpannerDatabaseInfo spannerDatabaseInfo = new SpannerDatabaseInfo(connection.getMetaData());
+      SpannerDatabaseInfo spannerDatabaseInfo =
+          new SpannerDatabaseInfo(metadata.getDatabase(), connection.getMetaData());
       tool.getSpannerTableExporter(options).init(metadata, spannerDatabaseInfo, Action.DROP);
       tool.getForeignKeyExporter(options).init(spannerDatabaseInfo);
       schemaDropper.doDrop(
@@ -84,7 +85,8 @@ public class SpannerSchemaDropper implements SchemaDropper {
     try {
       Connection connection = isolator.getIsolatedConnection();
       // Initialize exporters with drop table dependencies so tables are dropped in the right order.
-      SpannerDatabaseInfo spannerDatabaseInfo = new SpannerDatabaseInfo(connection.getMetaData());
+      SpannerDatabaseInfo spannerDatabaseInfo =
+          new SpannerDatabaseInfo(metadata.getDatabase(), connection.getMetaData());
       tool.getSpannerTableExporter(options).init(metadata, spannerDatabaseInfo, Action.DROP);
       tool.getForeignKeyExporter(options).init(spannerDatabaseInfo);
       return schemaDropper.buildDelayedAction(

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaMigrator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerSchemaMigrator.java
@@ -58,7 +58,8 @@ public class SpannerSchemaMigrator implements SchemaMigrator {
     DdlTransactionIsolator isolator = tool.getDdlTransactionIsolator(options);
     try {
       Connection connection = isolator.getIsolatedConnection();
-      SpannerDatabaseInfo spannerDatabaseInfo = new SpannerDatabaseInfo(connection.getMetaData());
+      SpannerDatabaseInfo spannerDatabaseInfo =
+          new SpannerDatabaseInfo(metadata.getDatabase(), connection.getMetaData());
       tool.getSpannerTableExporter(options).init(metadata, spannerDatabaseInfo, Action.UPDATE);
       tool.getForeignKeyExporter(options).init(spannerDatabaseInfo);
       schemaMigrator.doMigration(metadata, options, contributableInclusionFilter, targetDescriptor);

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerTableStatements.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/schema/SpannerTableStatements.java
@@ -23,6 +23,7 @@ import com.google.cloud.spanner.hibernate.BitReversedSequenceStyleGenerator.Repl
 import com.google.cloud.spanner.hibernate.Interleaved;
 import com.google.cloud.spanner.hibernate.SpannerDialect;
 import com.google.cloud.spanner.hibernate.types.SpannerArrayListType;
+import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import java.sql.Types;
 import java.text.MessageFormat;
@@ -68,7 +69,7 @@ public class SpannerTableStatements {
     if (existingTableIndices != null) {
       for (String indexName : getTableIndices(table)) {
         if (existingTableIndices.contains(indexName)) {
-          dropStrings.add("drop index " + indexName);
+          dropStrings.add("drop index " + getQualifiedIndexName(table, indexName));
         }
       }
     }
@@ -78,6 +79,13 @@ public class SpannerTableStatements {
           table.getQualifiedTableName().quote().getObjectName().toString()));
     }
     return dropStrings;
+  }
+
+  private String getQualifiedIndexName(Table table, String index) {
+    if (Strings.isNullOrEmpty(table.getSchema())) {
+      return index;
+    }
+    return table.getSchema() + "." + index;
   }
 
   private Set<String> getTableIndices(Table table) {

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedCreateTableStatementsTests.java
@@ -21,6 +21,8 @@ package com.google.cloud.spanner.hibernate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.hibernate.entities.Account;
@@ -38,8 +40,12 @@ import java.util.List;
 import org.hibernate.Session;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.boot.model.relational.Namespace.Name;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.mapping.Table;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -270,10 +276,14 @@ public class GeneratedCreateTableStatementsTests {
           new MetadataSources(this.registry)
               .addAnnotatedClass(Employee.class)
               .buildMetadata();
+      Namespace namespace = mock(Namespace.class);
+      when(namespace.getPhysicalName()).thenReturn(
+          new Name(Identifier.toIdentifier(""), Identifier.toIdentifier("")));
+      Table table = new Table("orm", namespace, Identifier.toIdentifier("Employee"), false);
 
       this.connection.setMetaData(MockJdbcUtils.metaDataBuilder()
           .setTables("Employee", "Employee_Sequence")
-          .setIndices("name_index")
+          .setIndices(table, "name_index")
           .build());
 
       Session session = metadata.buildSessionFactory().openSession();
@@ -286,8 +296,8 @@ public class GeneratedCreateTableStatementsTests {
       assertThat(sqlStrings).startsWith(
           "START BATCH DDL",
           "drop index name_index",
-          "drop table Employee",
-          "drop table Employee_Sequence",
+          "drop table `Employee`",
+          "drop table `Employee_Sequence`",
           "RUN BATCH"
       );
     } finally {
@@ -301,10 +311,14 @@ public class GeneratedCreateTableStatementsTests {
         new MetadataSources(this.registry)
             .addAnnotatedClass(Employee.class)
             .buildMetadata();
+    Namespace namespace = mock(Namespace.class);
+    when(namespace.getPhysicalName()).thenReturn(
+        new Name(Identifier.toIdentifier(""), Identifier.toIdentifier("")));
+    Table table = new Table("orm", namespace, Identifier.toIdentifier("Employee"), false);
 
     this.connection.setMetaData(MockJdbcUtils.metaDataBuilder()
         .setTables("Employee")
-        .setIndices("name_index")
+        .setIndices(table, "name_index")
         .build());
 
     Session session = metadata.buildSessionFactory().openSession();
@@ -317,7 +331,7 @@ public class GeneratedCreateTableStatementsTests {
     assertThat(sqlStrings).startsWith(
         "START BATCH DDL",
         "drop index name_index",
-        "drop table Employee",
+        "drop table `Employee`",
         "drop sequence Employee_Sequence",
         "RUN BATCH"
     );

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/MockJdbcUtils.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/MockJdbcUtils.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.hibernate.mapping.Table;
 
 /**
  * Helper class to building mock objects for the mock JDBC driver.
@@ -105,11 +106,13 @@ public class MockJdbcUtils {
   /**
    * Constructs a {@link MockResultSet} containing database metadata about indices for testing.
    */
-  private static ResultSet createIndexMetadataResultSet(String... indexNames) {
-    MockResultSet mockResultSet = initResultSet("INDEX_NAME");
+  private static ResultSet createIndexMetadataResultSet(Table table, String... indexNames) {
+    MockResultSet mockResultSet = initResultSet(
+        "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "INDEX_NAME");
 
     for (int i = 0; i < indexNames.length; i++) {
-      String[] row = new String[]{indexNames[i]};
+      String[] row =
+          new String[]{table.getCatalog(), table.getSchema(), table.getName(), indexNames[i]};
       mockResultSet.addRow(row);
     }
 
@@ -181,8 +184,8 @@ public class MockJdbcUtils {
     /**
      * Sets which indices are present in the Spanner database.
      */
-    public MockDatabaseMetaDataBuilder setIndices(String... indices) {
-      this.indexInfo = createIndexMetadataResultSet(indices);
+    public MockDatabaseMetaDataBuilder setIndices(Table table, String... indices) {
+      this.indexInfo = createIndexMetadataResultSet(table, indices);
       return this;
     }
 

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SchemaGenerationMockServerTest.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SchemaGenerationMockServerTest.java
@@ -249,13 +249,13 @@ public class SchemaGenerationMockServerTest extends AbstractSchemaGenerationMock
     assertEquals(7, request.getStatementsCount());
 
     int index = -1;
-    assertEquals("drop table Account", request.getStatements(++index));
-    assertEquals("drop table Customer", request.getStatements(++index));
-    assertEquals("drop table customerId", request.getStatements(++index));
-    assertEquals("drop table Invoice", request.getStatements(++index));
-    assertEquals("drop table invoiceId", request.getStatements(++index));
-    assertEquals("drop table Singer", request.getStatements(++index));
-    assertEquals("drop table singerId", request.getStatements(++index));
+    assertEquals("drop table `Account`", request.getStatements(++index));
+    assertEquals("drop table `Customer`", request.getStatements(++index));
+    assertEquals("drop table `customerId`", request.getStatements(++index));
+    assertEquals("drop table `Invoice`", request.getStatements(++index));
+    assertEquals("drop table `invoiceId`", request.getStatements(++index));
+    assertEquals("drop table `Singer`", request.getStatements(++index));
+    assertEquals("drop table `singerId`", request.getStatements(++index));
   }
   
   @Test

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerForeignKeyExporterTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerForeignKeyExporterTests.java
@@ -26,7 +26,11 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.spanner.hibernate.schema.SpannerDatabaseInfo;
 import com.google.cloud.spanner.hibernate.schema.SpannerForeignKeyExporter;
 import java.util.Collections;
+import java.util.Set;
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.boot.model.relational.Namespace.Name;
 import org.hibernate.boot.model.relational.QualifiedTableName;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.mapping.ForeignKey;
@@ -53,9 +57,14 @@ public class SpannerForeignKeyExporterTests {
    */
   @Before
   public void setup() {
+    Namespace namespace = mock(Namespace.class);
+    when(namespace.getPhysicalName()).thenReturn(
+        new Name(Identifier.toIdentifier(""), Identifier.toIdentifier("")));
     this.spannerDatabaseInfo = mock(SpannerDatabaseInfo.class);
-    when(spannerDatabaseInfo.getAllTables()).thenReturn(Collections.singleton("address"));
-    when(spannerDatabaseInfo.getImportedForeignKeys("address"))
+    Table table = new Table("orm", namespace, Identifier.toIdentifier("address"), false);
+    Set<Table> tables = Collections.singleton(table);
+    when(spannerDatabaseInfo.getAllTables()).thenReturn(tables);
+    when(spannerDatabaseInfo.getImportedForeignKeys(table))
         .thenReturn(Collections.singleton("address_fk"));
 
     this.metadata = mock(Metadata.class);
@@ -90,9 +99,11 @@ public class SpannerForeignKeyExporterTests {
   private static ForeignKey foreignKey(String tableName, String foreignKeyName) {
     ForeignKey foreignKey = new ForeignKey();
     foreignKey.setName(foreignKeyName);
-
-    Table table = new Table();
-    table.setName(tableName);
+    
+    Namespace namespace = mock(Namespace.class);
+    when(namespace.getPhysicalName()).thenReturn(
+        new Name(Identifier.toIdentifier(""), Identifier.toIdentifier("")));
+    Table table = new Table("orm", namespace, Identifier.toIdentifier(tableName), false);
     foreignKey.setTable(table);
     foreignKey.setReferencedTable(table);
 


### PR DESCRIPTION
Ensures that the Hibernate dialect is able to handle multiple schemas, potentially with tables with the same name in different schemas. This change does not introduce any specific support for named schemas, only preparations that ensure that nothing breaks if named schemas are used.