### PR TITLE
docs: Update README.adoc to reflect updated mutation limits

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -367,7 +367,7 @@ The Cloud Spanner Hibernate Dialect supports most of the standard Hibernate and 
 [options="header"]
 |===
 | Unsupported Feature | Description
-| Large DML Transactions | Each Spanner transaction may only have up to 40,000 operations which modify rows of a table.
+| Large DML Transactions | Each Spanner transaction may only have up to 80,000 operations which modify rows of a table.
 | Catalog and schema scoping for table names | Tables name references cannot contain periods or other punctuation.
 | Mutations | Cloud Spanner supports both DML and mutations for modifying data. Hibernate does not support mutations, and mutations can therefore not be used with this Hibernate dialect.
 | Locking | Cloud Spanner does not support explicit lock clauses. Setting the lock mode of a query is therefore not supported.
@@ -375,15 +375,15 @@ The Cloud Spanner Hibernate Dialect supports most of the standard Hibernate and 
 
 === Large DML Transactions Limits
 
-Cloud Spanner has a mutation limit on each transaction - each Spanner transaction https://cloud.google.com/spanner/quotas#limits_for_creating_reading_updating_and_deleting_data[may only have up to 40,000 operations which modify rows of a table].
+Cloud Spanner has a mutation limit on each transaction - each Spanner transaction https://cloud.google.com/spanner/quotas#limits-for[may only have up to 80,000 operations which modify rows of a table].
 
 NOTE: Deleting a row counts as one operation and inserting/updating a single row will https://cloud.google.com/spanner/quotas#note2[count as a number of operations equal to the number of affected columns].
 For example if one inserts a row that contains 5 columns, it counts as 5 modify operations for the insert.
 
 Consequently, users must take care to avoid encountering these constraints.
 
-1. We recommend being careful with the use of `CASCADE_TYPE.ALL` in Entity annotations because, depending on the application, it might trigger a large number of entities to be deleted in a single transaction and bring you over the 40,000 limit.
-2. Also, when persisting a collection of entities, be mindful of the 40,000 mutations per transaction constraint.
+1. We recommend being careful with the use of `CASCADE_TYPE.ALL` in Entity annotations because, depending on the application, it might trigger a large number of entities to be deleted in a single transaction and bring you over the 80,000 limit.
+2. Also, when persisting a collection of entities, be mindful of the 80,000 mutations per transaction constraint.
 
 === Catalog/Schema Table Names
 


### PR DESCRIPTION
Mutation limits have been updated to 80,000. 

Update README to reflect this, and correct link