### PR TITLE
fix: JSON nulls were inserted as STRINGs and rejected

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerDialect.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerDialect.java
@@ -101,6 +101,18 @@ public class SpannerDialect extends org.hibernate.dialect.SpannerDialect {
               value, getJavaType(), options);
           st.setObject(name, json, JsonType.VENDOR_TYPE_NUMBER);
         }
+
+        @Override
+        protected void doBindNull(PreparedStatement st, int index, WrapperOptions options)
+            throws SQLException {
+          st.setNull(index, JsonType.VENDOR_TYPE_NUMBER);
+        }
+
+        @Override
+        protected void doBindNull(CallableStatement st, String name, WrapperOptions options)
+            throws SQLException {
+          st.setNull(name, JsonType.VENDOR_TYPE_NUMBER);
+        }
       };
     }
   }

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/it/SampleModelIT.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/it/SampleModelIT.java
@@ -260,6 +260,20 @@ public class SampleModelIT {
   }
 
   @Test
+  public void testSaveVenueWithNullDescription() {
+    try (Session session = sessionFactory.openSession()) {
+      final Transaction transaction = session.beginTransaction();
+      Venue venue = new Venue("Venue 2", /* description = */ null);
+      session.persist(venue);
+      transaction.commit();
+
+      session.refresh(venue);
+      assertEquals("Venue 2", venue.getName());
+      assertNull(venue.getDescription());
+    }
+  }
+
+  @Test
   public void testSaveConcert() {
     try (Session session = sessionFactory.openSession()) {
       Singer peter = session.get(Singer.class, Long.reverse(50000L));


### PR DESCRIPTION
Null values for JSON columns were inserted with type STRING, and then rejected by Cloud Spanner. This change also overrides the setNull methods, so these also explicitly state that the null value is a JSON.