### PR TITLE
deps: bump Java version to 11 in parent project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <java.version>11</java.version>
     <hibernate.version>6.3.1.Final</hibernate.version>
     <spanner-jdbc-driver.version>2.16.1</spanner-jdbc-driver.version>
     <log4j.version>2.23.1</log4j.version>


### PR DESCRIPTION
Hibernate 6.x requires Java 11, and all underlying projects therefore also use Java 11. This updates the Java version in the parent project as well.