### PR TITLE
ci: run quarkus sample only with jdk17 or later

### DIFF
--- a/google-cloud-spanner-hibernate-samples/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/pom.xml
@@ -16,9 +16,10 @@
 
 	<profiles>
 		<profile>
-			<id>only-enable-spring-samples-when-jdk-17-or-later</id>
+			<id>samples-only-compatible-with-jdk-17-or-later</id>
 			<activation><jdk>[17,)</jdk></activation>
 			<modules>
+				<module>quarkus-jpa-sample</module>
 				<module>spring-data-jpa-sample</module>
 				<module>spring-data-jpa-full-sample</module>
 			</modules>
@@ -28,7 +29,6 @@
 	<modules>
 		<module>basic-hibernate-sample</module>
 		<module>microprofile-jpa-sample</module>
-		<module>quarkus-jpa-sample</module>
 		<module>spanner-hibernate-codelab</module>
 		<module>basic-spanner-features-sample</module>
 	</modules>


### PR DESCRIPTION
Quarkus 3.7+ requires JDK 17 as a minimum. (https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.7)

The sample in this repository currently uses 3.10.1.

See also recent Cloud Build failure: https://pantheon.corp.google.com/cloud-build/builds/0764fe35-8924-484a-b106-38b1a32b3f39?project=cloud-spanner-hibernate-ci