### PR TITLE
feat: support float32 type

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -133,7 +133,7 @@ sequence in the database.
 
 The `increment_size` for this pooled generator can not exceed 200.
 
-This is the **recommended configuration** for bit-reversed sequences: 
+This is the **recommended configuration** for bit-reversed sequences:
 
 [source, java]
 ----
@@ -318,6 +318,7 @@ This project offers the following Hibernate type mappings for specific Spanner c
 | `ARRAY<BOOL>`      | `com.google.cloud.spanner.hibernate.types.SpannerBoolArray`
 | `ARRAY<BYTES>`     | `com.google.cloud.spanner.hibernate.types.SpannerBytesArray`
 | `ARRAY<DATE>`      | `com.google.cloud.spanner.hibernate.types.SpannerDateArray`
+| `ARRAY<FLOAT32>`   | `com.google.cloud.spanner.hibernate.types.SpannerFloat32Array`
 | `ARRAY<FLOAT64>`   | `com.google.cloud.spanner.hibernate.types.SpannerFloat64Array`
 | `ARRAY<INT64>`     | `com.google.cloud.spanner.hibernate.types.SpannerInt64Array`
 | `ARRAY<JSON>`      | `com.google.cloud.spanner.hibernate.types.SpannerJsonArray`

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerDialect.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerDialect.java
@@ -18,6 +18,7 @@
 
 package com.google.cloud.spanner.hibernate;
 
+import static java.sql.Types.REAL;
 import static org.hibernate.type.SqlTypes.DECIMAL;
 import static org.hibernate.type.SqlTypes.JSON;
 import static org.hibernate.type.SqlTypes.NUMERIC;
@@ -188,6 +189,16 @@ public class SpannerDialect extends org.hibernate.dialect.SpannerDialect {
     }
     if (sqlTypeCode == JSON) {
       return "json";
+    }
+    // The JDBC spec is a bit confusing here.
+    // DOUBLE == FLOAT == 64 bit
+    // REAL == 32 bit
+    // The default Hibernate implementation did not really get this right, as it uses
+    // java.sql.Types.FLOAT for java.lang.Float. It should have been java.sql.Types.REAL.
+    // This dialect follows the default Hibernate implementation, and in order to actually
+    // use a float32, you need to annotate the column with the JDBC type code REAL.
+    if (sqlTypeCode == REAL) {
+      return "float32";
     }
     return super.columnType(sqlTypeCode);
   }

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/types/SpannerFloat32Array.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/types/SpannerFloat32Array.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019-2024 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate.types;
+
+import com.google.cloud.spanner.Type.Code;
+import java.util.List;
+
+/**
+ * Hibernate type definition for
+ *
+ * <pre>{@code ARRAY<FLOAT32>}</pre>
+ *
+ * .
+ */
+public class SpannerFloat32Array extends AbstractSpannerArrayType<Float, Float> {
+
+  @Override
+  public Code getSpannerTypeCode() {
+    return Code.FLOAT32;
+  }
+
+  @Override
+  public Float[] toArray(List<Float> value) {
+    return value == null ? null : value.toArray(new Float[0]);
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/types/internal/ArrayJavaTypeDescriptor.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/types/internal/ArrayJavaTypeDescriptor.java
@@ -141,6 +141,8 @@ public class ArrayJavaTypeDescriptor extends AbstractClassJavaType<List<?>>
       return Code.INT64;
     } else if (Double.class.isAssignableFrom(javaType)) {
       return Code.FLOAT64;
+    } else if (Float.class.isAssignableFrom(javaType)) {
+      return Code.FLOAT32;
     } else if (String.class.isAssignableFrom(javaType)) {
       return Code.STRING;
     } else if (UUID.class.isAssignableFrom(javaType)) {

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedSelectStatementsTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/GeneratedSelectStatementsTests.java
@@ -122,8 +122,8 @@ public class GeneratedSelectStatementsTests {
               .get();
       assertThat(preparedStatement)
           .isEqualTo(
-              "insert into `test_table` (`boolColumn`,longVal,stringVal,`ID1`,id2) "
-                  + "values (?,?,?,?,?)");
+              "insert into `test_table` (`boolColumn`,floatVal,floatValStoredAsDouble,longVal,stringVal,`ID1`,id2) "
+                  + "values (?,?,?,?,?,?,?)");
     }
   }
 

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SchemaGenerationMockServerTest.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SchemaGenerationMockServerTest.java
@@ -482,6 +482,8 @@ public class SchemaGenerationMockServerTest extends AbstractSchemaGenerationMock
                 + "`ID1` int64 not null,"
                 + "id2 string(255) not null,"
                 + "`boolColumn` bool,"
+                + "floatVal float32 not null,"
+                + "floatValStoredAsDouble float64 not null,"
                 + "longVal int64 not null,"
                 + "stringVal string(255)) PRIMARY KEY (`ID1`,id2)",
             request.getStatements(++index));
@@ -503,6 +505,8 @@ public class SchemaGenerationMockServerTest extends AbstractSchemaGenerationMock
         assertEquals(
             "create table `test_table` ("
                 + "`boolColumn` bool,"
+                + "floatVal float32 not null,"
+                + "floatValStoredAsDouble float64 not null,"
                 + "`ID1` int64 not null,"
                 + "longVal int64 not null,"
                 + "id2 string(255) not null,"

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SpannerTableExporterTests.java
@@ -242,8 +242,10 @@ public class SpannerTableExporterTests {
     // implementation maps types.
     String expectedCreateString =
         "create table `test_table` (`ID1` int64 not null,id2"
-            + " string(255) not null,`boolColumn` bool,longVal int64 not null,stringVal"
-            + " string(255)) PRIMARY KEY (`ID1`,id2);";
+            + " string(255) not null,`boolColumn` bool,"
+            + "floatVal float32 not null,floatValStoredAsDouble float64 not null,"
+            + "longVal int64 not null,"
+            + "stringVal string(255)) PRIMARY KEY (`ID1`,id2);";
 
     String expectedCollectionCreateString =
         "create table `TestEntity_stringList` "

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/entities/TestEntity.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/entities/TestEntity.java
@@ -25,7 +25,9 @@ import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import java.io.Serializable;
+import java.sql.Types;
 import java.util.List;
+import org.hibernate.annotations.JdbcTypeCode;
 
 /**
  * A test entity class used for generating schema statements.
@@ -45,6 +47,16 @@ public class TestEntity {
   public boolean boolVal;
 
   public long longVal;
+
+  // Types.REAL is the JDBC equivalent of a single-precision floating point number.
+  // This is translated to float32 in Spanner.
+  @JdbcTypeCode(Types.REAL)
+  public float floatVal;
+
+  // Hibernate translates java.lang.float to Types.FLOAT.
+  // According to the JDBC spec, Types.FLOAT == Types.DOUBLE.
+  // That means that this column is stored as a float64 in Spanner.
+  public float floatValStoredAsDouble;
 
   @ElementCollection List<String> stringList;
 

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/hints/HintsTest.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/hints/HintsTest.java
@@ -183,8 +183,6 @@ public class HintsTest {
         "@{STATEMENT_TAG=insert_singer}" + "insert into singers (id, value) SELECT * from singers",
         Hints.statementTag("insert_singer")
             .replace("insert into singers (id, value) SELECT * from singers"));
-
-    System.out.println(Hints.statementTag("get_albums_by_title").toComment());
   }
 
   @Test

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/it/SampleModelIT.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/it/SampleModelIT.java
@@ -48,9 +48,7 @@ import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Root;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.sql.Connection;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -58,14 +56,10 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
-import org.checkerframework.checker.initialization.qual.Initialized;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
-import org.hibernate.jdbc.Work;
 import org.hibernate.query.Query;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -538,15 +532,20 @@ public class SampleModelIT {
       assertEquals(saved.getColNumericArray(), fetched.getColNumericArray());
       assertEquals(saved.getColStringArray(), fetched.getColStringArray());
       assertEquals(saved.getColTimestampArray(), fetched.getColTimestampArray());
-      
+
       // Verify that float32 is actually used.
-      session.doWork(connection -> {
-        try (ResultSet column = connection.createStatement().executeQuery("select spanner_type from information_schema.columns where table_schema='' and table_name='AllTypes' and column_name='colFloat32'")) {
-          assertTrue(column.next());
-          assertEquals("FLOAT32", column.getString(1));
-          assertFalse(column.next());
-        }
-      });
+      session.doWork(
+          connection -> {
+            try (ResultSet column =
+                connection
+                    .createStatement()
+                    .executeQuery(
+                        "select spanner_type from information_schema.columns where table_schema='' and table_name='AllTypes' and column_name='colFloat32'")) {
+              assertTrue(column.next());
+              assertEquals("FLOAT32", column.getString(1));
+              assertFalse(column.next());
+            }
+          });
     }
   }
 

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/it/SampleModelIT.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/it/SampleModelIT.java
@@ -476,6 +476,7 @@ public class SampleModelIT {
       saved.setColBytes("test".getBytes(StandardCharsets.UTF_8));
       saved.setColDate(LocalDate.of(2024, 2, 2));
       saved.setColFloat64(3.14d);
+      saved.setColFloat32(2.71f);
       saved.setColInt64(100L);
       saved.setColJson("{\"key\":\"value\"}");
       saved.setColNumeric(new BigDecimal("6.626"));
@@ -490,6 +491,7 @@ public class SampleModelIT {
       saved.setColDateArray(
           Arrays.asList(LocalDate.of(2000, 1, 1), null, LocalDate.of(1970, 1, 1)));
       saved.setColFloat64Array(Arrays.asList(3.14d, null, 6.626d));
+      saved.setColFloat32Array(Arrays.asList(2.71f, null, 6.022f));
       saved.setColInt64Array(Arrays.asList(1L, null, 2L));
       saved.setColJsonArray(Arrays.asList("{\"key\":\"value1\"}", null, "{\"key\":\"value2\"}"));
       saved.setColNumericArray(Arrays.asList(BigDecimal.ZERO, null, BigDecimal.TEN));
@@ -509,6 +511,7 @@ public class SampleModelIT {
       assertArrayEquals(saved.getColBytes(), fetched.getColBytes());
       assertEquals(saved.getColDate(), fetched.getColDate());
       assertEquals(saved.getColFloat64(), fetched.getColFloat64());
+      assertEquals(saved.getColFloat32(), fetched.getColFloat32());
       assertEquals(saved.getColInt64(), fetched.getColInt64());
       assertEquals(saved.getColJson(), fetched.getColJson());
       assertEquals(saved.getColNumeric(), fetched.getColNumeric());
@@ -521,6 +524,7 @@ public class SampleModelIT {
       }
       assertEquals(saved.getColDateArray(), fetched.getColDateArray());
       assertEquals(saved.getColFloat64Array(), fetched.getColFloat64Array());
+      assertEquals(saved.getColFloat32Array(), fetched.getColFloat32Array());
       assertEquals(saved.getColInt64Array(), fetched.getColInt64Array());
       assertEquals(saved.getColJsonArray(), fetched.getColJsonArray());
       assertEquals(saved.getColNumericArray(), fetched.getColNumericArray());

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/it/model/AllTypes.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/it/model/AllTypes.java
@@ -31,9 +31,11 @@ import com.google.cloud.spanner.hibernate.types.SpannerTimestampArray;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import java.math.BigDecimal;
+import java.sql.Types;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.Type;
 
 /** Test entity for mapping all supported types. */
@@ -50,6 +52,7 @@ public class AllTypes extends AbstractBaseEntity {
 
   private Double colFloat64;
 
+  @JdbcTypeCode(Types.REAL)
   private Float colFloat32;
 
   private Long colInt64;

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/it/model/AllTypes.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/it/model/AllTypes.java
@@ -21,6 +21,7 @@ package com.google.cloud.spanner.hibernate.it.model;
 import com.google.cloud.spanner.hibernate.types.SpannerBoolArray;
 import com.google.cloud.spanner.hibernate.types.SpannerBytesArray;
 import com.google.cloud.spanner.hibernate.types.SpannerDateArray;
+import com.google.cloud.spanner.hibernate.types.SpannerFloat32Array;
 import com.google.cloud.spanner.hibernate.types.SpannerFloat64Array;
 import com.google.cloud.spanner.hibernate.types.SpannerInt64Array;
 import com.google.cloud.spanner.hibernate.types.SpannerJsonArray;
@@ -49,6 +50,8 @@ public class AllTypes extends AbstractBaseEntity {
 
   private Double colFloat64;
 
+  private Float colFloat32;
+
   private Long colInt64;
 
   private String colJson;
@@ -70,6 +73,9 @@ public class AllTypes extends AbstractBaseEntity {
 
   @Type(SpannerFloat64Array.class)
   private List<Double> colFloat64Array;
+
+  @Type(SpannerFloat32Array.class)
+  private List<Float> colFloat32Array;
 
   @Type(SpannerInt64Array.class)
   private List<Long> colInt64Array;
@@ -125,6 +131,14 @@ public class AllTypes extends AbstractBaseEntity {
 
   public void setColFloat64(Double colFloat64) {
     this.colFloat64 = colFloat64;
+  }
+
+  public Float getColFloat32() {
+    return colFloat32;
+  }
+
+  public void setColFloat32(Float colFloat32) {
+    this.colFloat32 = colFloat32;
   }
 
   public Long getColInt64() {
@@ -197,6 +211,14 @@ public class AllTypes extends AbstractBaseEntity {
 
   public void setColFloat64Array(List<Double> colFloat64Array) {
     this.colFloat64Array = colFloat64Array;
+  }
+
+  public List<Float> getColFloat32Array() {
+    return colFloat32Array;
+  }
+
+  public void setColFloat32Array(List<Float> colFloat32Array) {
+    this.colFloat32Array = colFloat32Array;
   }
 
   public List<Long> getColInt64Array() {


### PR DESCRIPTION
Adds support for `FLOAT32` to the Spanner Hibernate dialect. Note that Hibernate by default maps `java.lang.float` fields to the JDBC type `FLOAT`, which is the equivalent of `DOUBLE`, meaning that these fields by default use `FLOAT64` on Spanner.

Add `@JdbcTypeCode(Types.REAL)` to your field declaration to ensure that a `FLOAT32` column is used.