### PR TITLE
docs: sample for commit timestamps

### DIFF
--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/CommitTimestampGeneration.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/CommitTimestampGeneration.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019-2024 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.sample;
+
+import java.lang.reflect.Member;
+import java.util.EnumSet;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.generator.EventType;
+import org.hibernate.generator.EventTypeSets;
+import org.hibernate.generator.GeneratorCreationContext;
+import org.hibernate.generator.OnExecutionGenerator;
+
+/** Generator for pending_commit_timestamp(). */
+public class CommitTimestampGeneration implements OnExecutionGenerator {
+  private final EnumSet<EventType> eventTypes;
+
+  public CommitTimestampGeneration(
+      CreationCommitTimestamp annotation, Member member, GeneratorCreationContext context) {
+    this.eventTypes = EventTypeSets.INSERT_ONLY;
+  }
+
+  public CommitTimestampGeneration(
+      UpdateCommitTimestamp annotation, Member member, GeneratorCreationContext context) {
+    this.eventTypes = EventTypeSets.UPDATE_ONLY;
+  }
+
+  @Override
+  public boolean referenceColumnsInSql(Dialect dialect) {
+    return true;
+  }
+
+  @Override
+  public boolean writePropertyValue() {
+    return false;
+  }
+
+  @Override
+  public String[] getReferencedColumnValues(Dialect dialect) {
+    return new String[] {"pending_commit_timestamp()"};
+  }
+
+  @Override
+  public EnumSet<EventType> getEventTypes() {
+    return eventTypes;
+  }
+}

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/CreationCommitTimestamp.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/CreationCommitTimestamp.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019-2024 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.sample;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.hibernate.annotations.ValueGenerationType;
+
+/**
+ * Annotation for columns that should automatically be assigned pending_commit_timestamp when a new
+ * entity is created.
+ */
+@ValueGenerationType(generatedBy = CommitTimestampGeneration.class)
+@Retention(RUNTIME)
+@Target({FIELD, METHOD})
+public @interface CreationCommitTimestamp {}

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/SampleApplication.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/SampleApplication.java
@@ -129,6 +129,10 @@ public class SampleApplication implements CommandLineRunner {
     // Select all active singers. This query uses a FORCE_INDEX query hint.
     List<Singer> activeSingers = singerService.getActiveSingers();
     log.info("Found {} active singers", activeSingers.size());
+    // Deactivate one of the singers.
+    if (!activeSingers.isEmpty()) {
+      singerService.deactivateSinger(activeSingers.get(0));
+    }
   }
 
   void printData() {

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/SingleTableWithCommitTimestampEntityPersister.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/SingleTableWithCommitTimestampEntityPersister.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019-2024 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.sample;
+
+import static org.hibernate.generator.EventType.INSERT;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hibernate.HibernateException;
+import org.hibernate.cache.spi.access.EntityDataAccess;
+import org.hibernate.cache.spi.access.NaturalIdDataAccess;
+import org.hibernate.generator.EventType;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.metamodel.mapping.AttributeMapping;
+import org.hibernate.metamodel.mapping.internal.GeneratedValuesProcessor;
+import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
+import org.hibernate.persister.entity.SingleTableEntityPersister;
+
+/**
+ * This custom persister ensures two things:
+ *
+ * <ol>
+ *   <li>Hibernate does not execute a SELECT after inserting/updating an entity with a commit
+ *       timestamp column to fetch the generated value. This value can only be fetched after the
+ *       transaction has committed.
+ *   <li>Batching of inserts is still supported, even though the entity has a generated commit
+ *       timestamp.
+ * </ol>
+ */
+public class SingleTableWithCommitTimestampEntityPersister extends SingleTableEntityPersister {
+
+  public SingleTableWithCommitTimestampEntityPersister(
+      PersistentClass persistentClass,
+      EntityDataAccess cacheAccessStrategy,
+      NaturalIdDataAccess naturalIdRegionAccessStrategy,
+      RuntimeModelCreationContext creationContext)
+      throws HibernateException {
+    super(persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext);
+  }
+
+  @Override
+  protected GeneratedValuesProcessor createGeneratedValuesProcessor(
+      EventType timing, List<AttributeMapping> generatedAttributes) {
+    // Skip all commit timestamp generated attributes, as these are not selectable.
+    return new GeneratedValuesProcessor(
+        this,
+        getGeneratedAttributesWithoutCommitTimestamp(generatedAttributes),
+        timing,
+        getFactory());
+  }
+
+  List<AttributeMapping> getGeneratedAttributesWithoutCommitTimestamp(
+      List<AttributeMapping> attributes) {
+    return attributes.stream()
+        .filter(attribute -> !(attribute.getGenerator() instanceof CommitTimestampGeneration))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean hasInsertGeneratedProperties() {
+    List<AttributeMapping> generatedAttributes =
+        GeneratedValuesProcessor.getGeneratedAttributes(this, INSERT);
+    return super.hasInsertGeneratedProperties()
+        && !getGeneratedAttributesWithoutCommitTimestamp(generatedAttributes).isEmpty();
+  }
+}

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/UpdateCommitTimestamp.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/UpdateCommitTimestamp.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019-2024 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.sample;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.hibernate.annotations.ValueGenerationType;
+
+/**
+ * Annotation for columns that should automatically be assigned pending_commit_timestamp when a new
+ * entity is updated.
+ */
+@ValueGenerationType(generatedBy = CommitTimestampGeneration.class)
+@Retention(RUNTIME)
+@Target({FIELD, METHOD})
+public @interface UpdateCommitTimestamp {}

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/AbstractEntity.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/AbstractEntity.java
@@ -18,9 +18,12 @@
 
 package com.google.cloud.spanner.sample.entities;
 
+import com.google.cloud.spanner.sample.CreationCommitTimestamp;
+import com.google.cloud.spanner.sample.UpdateCommitTimestamp;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import java.time.OffsetDateTime;
+import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -36,6 +39,56 @@ public class AbstractEntity {
 
   @Column @UpdateTimestamp private OffsetDateTime updatedAt;
 
+  /**
+   * This column shows how to automatically set the value to the pending_commit_timestamp() when a
+   * row is INSERTED. This achieved like this:
+   *
+   * <ol>
+   *   <li>Add a @CreationCommitTimestamp annotation.
+   *   <li>Set updatable=false to prevent it from being set when the row is updated.
+   *   <li>Add a ColumnTransformer to change the behavior when the value is read. The read
+   *       expression is set to a fixed timestamp. This means that Hibernate will always execute a
+   *       "select timestamp '0001-01-01T00:00:00Z'" instead of "select commitTimestampCreated".
+   *       This again prevents the column from being included in select statements, which again
+   *       means that the application will never fail due to the limitation that Spanner sets that
+   *       columns that have a pending_commit_timestamp value set cannot be read during the same
+   *       transaction. See <a
+   *       href="https://cloud.google.com/spanner/docs/commit-timestamp#dml">https://cloud.google.com/spanner/docs/commit-timestamp#dml</a>
+   *       for more information on this. This annotation can be removed if you are absolutely sure
+   *       that your application never reads the column in a transaction that has written a value to
+   *       the column.
+   * </ol>
+   */
+  @Column(updatable = false, columnDefinition = "timestamp options (allow_commit_timestamp=true)")
+  @CreationCommitTimestamp
+  @ColumnTransformer(read = "timestamp '0001-01-01T00:00:00Z'")
+  private OffsetDateTime commitTimestampCreated;
+
+  /**
+   * This column shows how to automatically set the value to the pending_commit_timestamp() when a
+   * row is UPDATED. This achieved like this:
+   *
+   * <ol>
+   *   <li>Add a @CreationCommitTimestamp annotation.
+   *   <li>Set insertable=false to prevent it from being set when the row is updated.
+   *   <li>Add a ColumnTransformer to change the behavior when the value is read. The read
+   *       expression is set to a fixed timestamp. This means that Hibernate will always execute a
+   *       "select timestamp '0001-01-01T00:00:00Z'" instead of "select commitTimestampCreated".
+   *       This again prevents the column from being included in select statements, which again
+   *       means that the application will never fail due to the limitation that Spanner sets that
+   *       columns that have a pending_commit_timestamp value set cannot be read during the same
+   *       transaction. See <a
+   *       href="https://cloud.google.com/spanner/docs/commit-timestamp#dml">https://cloud.google.com/spanner/docs/commit-timestamp#dml</a>
+   *       for more information on this. This annotation can be removed if you are absolutely sure
+   *       that your application never reads the column in a transaction that has written a value to
+   *       the column.
+   * </ol>
+   */
+  @Column(insertable = false, columnDefinition = "timestamp options (allow_commit_timestamp=true)")
+  @UpdateCommitTimestamp()
+  @ColumnTransformer(read = "timestamp '0001-01-01T00:00:00Z'")
+  private OffsetDateTime commitTimestampUpdated;
+
   public OffsetDateTime getCreatedAt() {
     return createdAt;
   }
@@ -50,5 +103,21 @@ public class AbstractEntity {
 
   public void setUpdatedAt(OffsetDateTime updatedAt) {
     this.updatedAt = updatedAt;
+  }
+
+  public OffsetDateTime getCommitTimestampCreated() {
+    return commitTimestampCreated;
+  }
+
+  public void setCommitTimestampCreated(OffsetDateTime commitTimestampCreated) {
+    this.commitTimestampCreated = commitTimestampCreated;
+  }
+
+  public OffsetDateTime getCommitTimestampUpdated() {
+    return commitTimestampUpdated;
+  }
+
+  public void setCommitTimestampUpdated(OffsetDateTime commitTimestampUpdated) {
+    this.commitTimestampUpdated = commitTimestampUpdated;
   }
 }

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/Album.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/Album.java
@@ -18,6 +18,7 @@
 
 package com.google.cloud.spanner.sample.entities;
 
+import com.google.cloud.spanner.sample.SingleTableWithCommitTimestampEntityPersister;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -27,8 +28,10 @@ import jakarta.persistence.OneToMany;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import org.hibernate.annotations.Persister;
 
 @Entity
+@Persister(impl = SingleTableWithCommitTimestampEntityPersister.class)
 public class Album extends AbstractNonInterleavedEntity {
 
   @Basic(optional = false)

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/Concert.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/Concert.java
@@ -18,12 +18,15 @@
 
 package com.google.cloud.spanner.sample.entities;
 
+import com.google.cloud.spanner.sample.SingleTableWithCommitTimestampEntityPersister;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
 import java.time.OffsetDateTime;
+import org.hibernate.annotations.Persister;
 
 @Entity
+@Persister(impl = SingleTableWithCommitTimestampEntityPersister.class)
 public class Concert extends AbstractNonInterleavedEntity {
 
   private String name;

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/Singer.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/Singer.java
@@ -19,6 +19,7 @@
 package com.google.cloud.spanner.sample.entities;
 
 import com.google.cloud.spanner.hibernate.types.SpannerStringArray;
+import com.google.cloud.spanner.sample.SingleTableWithCommitTimestampEntityPersister;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
@@ -26,10 +27,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.List;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Persister;
 import org.hibernate.annotations.Type;
 
 @Entity
+@DynamicUpdate
 @Table(indexes = {@Index(name = "idx_singer_active", columnList = "active")})
+@Persister(impl = SingleTableWithCommitTimestampEntityPersister.class)
 public class Singer extends AbstractNonInterleavedEntity {
 
   @Column(length = 100)

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/TicketSale.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/TicketSale.java
@@ -20,6 +20,7 @@ package com.google.cloud.spanner.sample.entities;
 
 import com.google.cloud.spanner.hibernate.PooledBitReversedSequenceStyleGenerator;
 import com.google.cloud.spanner.hibernate.types.SpannerStringArray;
+import com.google.cloud.spanner.sample.SingleTableWithCommitTimestampEntityPersister;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -30,11 +31,13 @@ import java.math.BigDecimal;
 import java.util.List;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.Persister;
 import org.hibernate.annotations.Type;
 import org.hibernate.id.enhanced.SequenceStyleGenerator;
 
 /** {@link TicketSale} shows how to use bit-reversed sequences to generate primary key values. */
 @Entity
+@Persister(impl = SingleTableWithCommitTimestampEntityPersister.class)
 public class TicketSale extends AbstractEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ticketSaleId")

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/Track.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/Track.java
@@ -19,6 +19,7 @@
 package com.google.cloud.spanner.sample.entities;
 
 import com.google.cloud.spanner.hibernate.Interleaved;
+import com.google.cloud.spanner.sample.SingleTableWithCommitTimestampEntityPersister;
 import com.google.cloud.spanner.sample.entities.Track.TrackId;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
@@ -34,11 +35,13 @@ import java.sql.Types;
 import java.util.Objects;
 import java.util.UUID;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Persister;
 import org.springframework.data.domain.Persistable;
 
 /** Track is interleaved in Album, and therefore uses a composite primary key. */
 @Interleaved(parentEntity = Album.class, cascadeDelete = true)
 @Entity
+@Persister(impl = SingleTableWithCommitTimestampEntityPersister.class)
 public class Track extends AbstractEntity implements Persistable<TrackId> {
 
   /**

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/Venue.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/Venue.java
@@ -18,15 +18,18 @@
 
 package com.google.cloud.spanner.sample.entities;
 
+import com.google.cloud.spanner.sample.SingleTableWithCommitTimestampEntityPersister;
 import jakarta.persistence.Entity;
 import java.io.Serializable;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Persister;
 import org.hibernate.type.SqlTypes;
 
 @Entity
 // Use DynamicUpdate to prevent the JSON column from being updated everytime this entity is updated.
 @DynamicUpdate
+@Persister(impl = SingleTableWithCommitTimestampEntityPersister.class)
 public class Venue extends AbstractNonInterleavedEntity {
 
   /**

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/service/SingerService.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/service/SingerService.java
@@ -29,6 +29,7 @@ import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -102,8 +103,16 @@ public class SingerService {
       singer.setFirstName(randomDataService.getRandomFirstName());
       singer.setLastName(randomDataService.getRandomLastName());
       singer.setNickNames(randomDataService.getRandomNickNames());
+      singer.setActive(ThreadLocalRandom.current().nextBoolean());
       singers.add(singer);
     }
     return repository.saveAll(singers);
+  }
+
+  @Transactional
+  @TransactionTag("deactivate_singer")
+  public void deactivateSinger(Singer singer) {
+    singer.setActive(false);
+    repository.save(singer);
   }
 }

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/test/java/com/google/cloud/spanner/sample/SampleApplicationMockServerTest.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/test/java/com/google/cloud/spanner/sample/SampleApplicationMockServerTest.java
@@ -43,6 +43,7 @@ import com.google.spanner.v1.TypeCode;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Base64;
+import java.util.List;
 import java.util.UUID;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -250,52 +251,59 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
     mockSpanner.putStatementResults(
         StatementResult.query(
             Statement.of(
-                "select ts1_0.id,ts1_0.concert_id,ts1_0.created_at,ts1_0.customer_name,ts1_0.price,ts1_0.seats,ts1_0.updated_at from ticket_sale ts1_0"),
+                "select ts1_0.id,timestamp '0001-01-01T00:00:00Z',timestamp '0001-01-01T00:00:00Z',ts1_0.concert_id,ts1_0.created_at,ts1_0.customer_name,ts1_0.price,ts1_0.seats,ts1_0.updated_at from ticket_sale ts1_0"),
             empty()));
     mockSpanner.putStatementResult(
         StatementResult.query(
             Statement.of(
-                "select c1_0.id,c1_0.created_at,c1_0.end_time,c1_0.name,c1_0.singer_id,c1_0.start_time,c1_0.updated_at,c1_0.venue_id from concert c1_0"),
+                "select c1_0.id,timestamp '0001-01-01T00:00:00Z',timestamp '0001-01-01T00:00:00Z',c1_0.created_at,c1_0.end_time,c1_0.name,c1_0.singer_id,c1_0.start_time,c1_0.updated_at,c1_0.venue_id from concert c1_0"),
             empty()));
     mockSpanner.putStatementResult(
         StatementResult.query(
             Statement.of(
-                "select a1_0.id,a1_0.cover_picture,a1_0.created_at,a1_0.marketing_budget,a1_0.release_date,a1_0.singer_id,a1_0.title,a1_0.updated_at from album a1_0"),
+                "select a1_0.id,timestamp '0001-01-01T00:00:00Z',timestamp '0001-01-01T00:00:00Z',a1_0.cover_picture,a1_0.created_at,a1_0.marketing_budget,a1_0.release_date,a1_0.singer_id,a1_0.title,a1_0.updated_at from album a1_0"),
             empty()));
     mockSpanner.putStatementResult(
         StatementResult.query(
             Statement.of(
-                "select s1_0.id,s1_0.active,s1_0.created_at,s1_0.first_name,s1_0.full_name,s1_0.last_name,s1_0.nick_names,s1_0.updated_at from singer s1_0"),
+                "select s1_0.id,s1_0.active,timestamp '0001-01-01T00:00:00Z',timestamp '0001-01-01T00:00:00Z',s1_0.created_at,s1_0.first_name,s1_0.full_name,s1_0.last_name,s1_0.nick_names,s1_0.updated_at from singer s1_0"),
             empty()));
 
     // Add results for the insert statements.
     mockSpanner.putPartialStatementResult(
         StatementResult.update(
             Statement.of(
-                "insert into singer (active,created_at,first_name,last_name,nick_names,updated_at,id) values (@p1,@p2,@p3,@p4,@p5,@p6,@p7)"),
+                "insert into singer (active,commit_timestamp_created,created_at,first_name,last_name,nick_names,updated_at,id) values (@p1,pending_commit_timestamp(),@p2,@p3,@p4,@p5,@p6,@p7)"),
             1L));
     mockSpanner.putPartialStatementResult(
         StatementResult.update(
             Statement.of(
-                "insert into album (cover_picture,created_at,marketing_budget,release_date,singer_id,title,updated_at,id) values (@p1,@p2,@p3,@p4,@p5,@p6,@p7,@p8)"),
+                "insert into album (commit_timestamp_created,cover_picture,created_at,marketing_budget,release_date,singer_id,title,updated_at,id) values (pending_commit_timestamp(),@p1,@p2,@p3,@p4,@p5,@p6,@p7,@p8)"),
             1L));
     mockSpanner.putPartialStatementResult(
         StatementResult.update(
             Statement.of(
-                "insert into track (created_at,sample_rate,title,updated_at,id,track_number) values (@p1,@p2,@p3,@p4,@p5,@p6)"),
+                "insert into track (commit_timestamp_created,created_at,sample_rate,title,updated_at,id,track_number) values (pending_commit_timestamp(),@p1,@p2,@p3,@p4,@p5,@p6)"),
             1L));
     mockSpanner.putPartialStatementResult(
         StatementResult.update(
             Statement.of(
-                "insert into venue (created_at,description,name,updated_at,id) values (@p1,@p2,@p3,@p4,@p5)"),
+                "insert into venue (commit_timestamp_created,created_at,description,name,updated_at,id) values (pending_commit_timestamp(),@p1,@p2,@p3,@p4,@p5)"),
             1L));
     mockSpanner.putPartialStatementResult(
         StatementResult.update(
-            Statement.of("update venue set description=@p1,updated_at=@p2 where id=@p3"), 1L));
+            Statement.of(
+                "update venue set commit_timestamp_updated=pending_commit_timestamp(),description=@p1,updated_at=@p2 where id=@p3"),
+            1L));
     mockSpanner.putPartialStatementResult(
         StatementResult.update(
             Statement.of(
-                "insert into concert (created_at,end_time,name,singer_id,start_time,updated_at,venue_id,id) values (@p1,@p2,@p3,@p4,@p5,@p6,@p7,@p8)"),
+                "insert into concert (commit_timestamp_created,created_at,end_time,name,singer_id,start_time,updated_at,venue_id,id) values (pending_commit_timestamp(),@p1,@p2,@p3,@p4,@p5,@p6,@p7,@p8)"),
+            1L));
+    mockSpanner.putPartialStatementResult(
+        StatementResult.update(
+            Statement.of(
+                "update singer set active=@p1,commit_timestamp_updated=pending_commit_timestamp(),updated_at=@p2 where id=@p3"),
             1L));
 
     // Add results for selecting singers.
@@ -315,6 +323,16 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
                                 Field.newBuilder()
                                     .setName("active")
                                     .setType(Type.newBuilder().setCode(TypeCode.BOOL).build())
+                                    .build())
+                            .addFields(
+                                Field.newBuilder()
+                                    .setName("")
+                                    .setType(Type.newBuilder().setCode(TypeCode.TIMESTAMP).build())
+                                    .build())
+                            .addFields(
+                                Field.newBuilder()
+                                    .setName("")
+                                    .setType(Type.newBuilder().setCode(TypeCode.TIMESTAMP).build())
                                     .build())
                             .addFields(
                                 Field.newBuilder()
@@ -357,6 +375,8 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
                 ListValue.newBuilder()
                     .addValues(Value.newBuilder().setStringValue(singerId.toString()).build())
                     .addValues(Value.newBuilder().setBoolValue(true).build())
+                    .addValues(Value.newBuilder().setStringValue("0001-01-01T00:00:00Z").build())
+                    .addValues(Value.newBuilder().setStringValue("0001-01-01T00:00:00Z").build())
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(OffsetDateTime.now(ZoneId.of("UTC")).toString())
@@ -381,7 +401,7 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
     mockSpanner.putStatementResult(
         StatementResult.query(
             Statement.newBuilder(
-                    "select s1_0.id,s1_0.active,s1_0.created_at,s1_0.first_name,s1_0.full_name,s1_0.last_name,s1_0.nick_names,s1_0.updated_at from singer s1_0 limit @p1 offset @p2")
+                    "select s1_0.id,s1_0.active,timestamp '0001-01-01T00:00:00Z',timestamp '0001-01-01T00:00:00Z',s1_0.created_at,s1_0.first_name,s1_0.full_name,s1_0.last_name,s1_0.nick_names,s1_0.updated_at from singer s1_0 limit @p1 offset @p2")
                 .bind("p1")
                 .to(20L)
                 .bind("p2")
@@ -391,7 +411,7 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
     mockSpanner.putStatementResult(
         StatementResult.query(
             Statement.newBuilder(
-                    "select s1_0.id,s1_0.active,s1_0.created_at,s1_0.first_name,s1_0.full_name,s1_0.last_name,s1_0.nick_names,s1_0.updated_at from singer s1_0 where s1_0.id=@p1")
+                    "select s1_0.id,s1_0.active,timestamp '0001-01-01T00:00:00Z',timestamp '0001-01-01T00:00:00Z',s1_0.created_at,s1_0.first_name,s1_0.full_name,s1_0.last_name,s1_0.nick_names,s1_0.updated_at from singer s1_0 where s1_0.id=@p1")
                 .bind("p1")
                 .to(singerId.toString())
                 .build(),
@@ -399,12 +419,12 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
     mockSpanner.putPartialStatementResult(
         StatementResult.query(
             Statement.of(
-                "select s1_0.id,s1_0.active,s1_0.created_at,s1_0.first_name,s1_0.full_name,s1_0.last_name,s1_0.nick_names,s1_0.updated_at from singer s1_0 where starts_with(s1_0.last_name,@p1)=true"),
+                "select s1_0.id,s1_0.active,timestamp '0001-01-01T00:00:00Z',timestamp '0001-01-01T00:00:00Z',s1_0.created_at,s1_0.first_name,s1_0.full_name,s1_0.last_name,s1_0.nick_names,s1_0.updated_at from singer s1_0 where starts_with(s1_0.last_name,@p1)=true"),
             singerResultSet));
     mockSpanner.putStatementResult(
         StatementResult.query(
             Statement.newBuilder(
-                    "select s1_0.id,s1_0.active,s1_0.created_at,s1_0.first_name,s1_0.full_name,s1_0.last_name,s1_0.nick_names,s1_0.updated_at from singer @{FORCE_INDEX=idx_singer_active} s1_0 where s1_0.active=@p1")
+                    "select s1_0.id,s1_0.active,timestamp '0001-01-01T00:00:00Z',timestamp '0001-01-01T00:00:00Z',s1_0.created_at,s1_0.first_name,s1_0.full_name,s1_0.last_name,s1_0.nick_names,s1_0.updated_at from singer @{FORCE_INDEX=idx_singer_active} s1_0 where s1_0.active=@p1")
                 .bind("p1")
                 .to(true)
                 .build(),
@@ -421,6 +441,16 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
                                 Field.newBuilder()
                                     .setName("id")
                                     .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                                    .build())
+                            .addFields(
+                                Field.newBuilder()
+                                    .setName("")
+                                    .setType(Type.newBuilder().setCode(TypeCode.TIMESTAMP).build())
+                                    .build())
+                            .addFields(
+                                Field.newBuilder()
+                                    .setName("")
+                                    .setType(Type.newBuilder().setCode(TypeCode.TIMESTAMP).build())
                                     .build())
                             .addFields(
                                 Field.newBuilder()
@@ -463,6 +493,8 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
                 ListValue.newBuilder()
                     .addValues(
                         Value.newBuilder().setStringValue(UUID.randomUUID().toString()).build())
+                    .addValues(Value.newBuilder().setStringValue("0001-01-01T00:00:00Z").build())
+                    .addValues(Value.newBuilder().setStringValue("0001-01-01T00:00:00Z").build())
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(
@@ -485,7 +517,7 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
     mockSpanner.putStatementResult(
         StatementResult.query(
             Statement.newBuilder(
-                    "select a1_0.id,a1_0.cover_picture,a1_0.created_at,a1_0.marketing_budget,a1_0.release_date,a1_0.singer_id,a1_0.title,a1_0.updated_at from album a1_0 limit @p1 offset @p2")
+                    "select a1_0.id,timestamp '0001-01-01T00:00:00Z',timestamp '0001-01-01T00:00:00Z',a1_0.cover_picture,a1_0.created_at,a1_0.marketing_budget,a1_0.release_date,a1_0.singer_id,a1_0.title,a1_0.updated_at from album a1_0 limit @p1 offset @p2")
                 .bind("p1")
                 .to(30L)
                 .bind("p2")
@@ -495,7 +527,7 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
     mockSpanner.putStatementResult(
         StatementResult.query(
             Statement.newBuilder(
-                    "select a1_0.singer_id,a1_0.id,a1_0.cover_picture,a1_0.created_at,a1_0.marketing_budget,a1_0.release_date,a1_0.title,a1_0.updated_at from album a1_0 where a1_0.singer_id=@p1")
+                    "select a1_0.singer_id,a1_0.id,timestamp '0001-01-01T00:00:00Z',timestamp '0001-01-01T00:00:00Z',a1_0.cover_picture,a1_0.created_at,a1_0.marketing_budget,a1_0.release_date,a1_0.title,a1_0.updated_at from album a1_0 where a1_0.singer_id=@p1")
                 .bind("p1")
                 .to(singerId.toString())
                 .build(),
@@ -513,6 +545,18 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
                                     Field.newBuilder()
                                         .setName("id")
                                         .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                                        .build())
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("")
+                                        .setType(
+                                            Type.newBuilder().setCode(TypeCode.TIMESTAMP).build())
+                                        .build())
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("")
+                                        .setType(
+                                            Type.newBuilder().setCode(TypeCode.TIMESTAMP).build())
                                         .build())
                                 .addFields(
                                     Field.newBuilder()
@@ -555,6 +599,10 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
                         .addValues(
                             Value.newBuilder().setStringValue(UUID.randomUUID().toString()).build())
                         .addValues(
+                            Value.newBuilder().setStringValue("0001-01-01T00:00:00Z").build())
+                        .addValues(
+                            Value.newBuilder().setStringValue("0001-01-01T00:00:00Z").build())
+                        .addValues(
                             Value.newBuilder()
                                 .setStringValue(
                                     Base64.getEncoder().encodeToString(new byte[] {1, 2, 3}))
@@ -576,14 +624,14 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
     mockSpanner.putPartialStatementResult(
         StatementResult.query(
             Statement.of(
-                "select t1_0.id,t1_0.track_number,t1_0.created_at,t1_0.sample_rate,t1_0.title,t1_0.updated_at from track t1_0 where t1_0.id=@p1"),
+                "select t1_0.id,t1_0.track_number,timestamp '0001-01-01T00:00:00Z',timestamp '0001-01-01T00:00:00Z',t1_0.created_at,t1_0.sample_rate,t1_0.title,t1_0.updated_at from track t1_0 where t1_0.id=@p1"),
             empty()));
 
     // Add results for selecting venues.
     mockSpanner.putStatementResult(
         StatementResult.query(
             Statement.of(
-                "select v1_0.id,v1_0.created_at,v1_0.description,v1_0.name,v1_0.updated_at from venue v1_0"),
+                "select v1_0.id,timestamp '0001-01-01T00:00:00Z',timestamp '0001-01-01T00:00:00Z',v1_0.created_at,v1_0.description,v1_0.name,v1_0.updated_at from venue v1_0"),
             ResultSet.newBuilder()
                 .setMetadata(
                     ResultSetMetadata.newBuilder()
@@ -593,6 +641,18 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
                                     Field.newBuilder()
                                         .setName("id")
                                         .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                                        .build())
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("")
+                                        .setType(
+                                            Type.newBuilder().setCode(TypeCode.TIMESTAMP).build())
+                                        .build())
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("")
+                                        .setType(
+                                            Type.newBuilder().setCode(TypeCode.TIMESTAMP).build())
                                         .build())
                                 .addFields(
                                     Field.newBuilder()
@@ -623,6 +683,10 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
                         .addValues(
                             Value.newBuilder().setStringValue(UUID.randomUUID().toString()).build())
                         .addValues(
+                            Value.newBuilder().setStringValue("0001-01-01T00:00:00Z").build())
+                        .addValues(
+                            Value.newBuilder().setStringValue("0001-01-01T00:00:00Z").build())
+                        .addValues(
                             Value.newBuilder()
                                 .setStringValue(OffsetDateTime.now(ZoneId.of("UTC")).toString())
                                 .build())
@@ -641,7 +705,7 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
     mockSpanner.putStatementResult(
         StatementResult.query(
             Statement.newBuilder(
-                    "select c1_0.singer_id,c1_0.id,c1_0.created_at,c1_0.end_time,c1_0.name,c1_0.start_time,c1_0.updated_at,c1_0.venue_id from concert c1_0 where c1_0.singer_id=@p1")
+                    "select c1_0.singer_id,c1_0.id,timestamp '0001-01-01T00:00:00Z',timestamp '0001-01-01T00:00:00Z',c1_0.created_at,c1_0.end_time,c1_0.name,c1_0.start_time,c1_0.updated_at,c1_0.venue_id from concert c1_0 where c1_0.singer_id=@p1")
                 .bind("p1")
                 .to(singerId.toString())
                 .build(),
@@ -677,6 +741,29 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
     mockSpanner.putStatementResult(
         StatementResult.query(
             Statement.newBuilder(selectAlbumsSql).bind("p1").to("Foo").build(), empty()));
+
+    String selectCommitTimestampSql = "select timestamp '0001-01-01T00:00:00Z'";
+    mockSpanner.putPartialStatementResult(
+        StatementResult.query(
+            Statement.of(selectCommitTimestampSql),
+            ResultSet.newBuilder()
+                .setMetadata(
+                    ResultSetMetadata.newBuilder()
+                        .setRowType(
+                            StructType.newBuilder()
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setType(
+                                            Type.newBuilder().setCode(TypeCode.TIMESTAMP).build())
+                                        .build())
+                                .build())
+                        .build())
+                .addRows(
+                    ListValue.newBuilder()
+                        .addValues(
+                            Value.newBuilder().setStringValue("0001-01-01T00:00:00Z").build())
+                        .build())
+                .build()));
   }
 
   @Test
@@ -688,18 +775,20 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
     System.setProperty("spanner.auto_tag_transactions", "true");
     SpringApplication.run(SampleApplication.class).close();
 
+    List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
     assertEquals(
-        35,
+        37,
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).stream()
             .filter(request -> !request.getSql().equals("SELECT 1"))
             .filter(
                 request ->
                     !request
                         .getSql()
-                        .equals("update venue set description=@p1,updated_at=@p2 where id=@p3"))
+                        .equals(
+                            "update venue set commit_timestamp_updated=pending_commit_timestamp(),description=@p1,updated_at=@p2 where id=@p3"))
             .count());
     assertEquals(6, mockSpanner.countRequestsOfType(ExecuteBatchDmlRequest.class));
-    assertEquals(11, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertEquals(12, mockSpanner.countRequestsOfType(CommitRequest.class));
 
     // Verify that we receive a transaction tag for the generateRandomVenues() method.
     assertEquals(
@@ -778,6 +867,16 @@ public class SampleApplicationMockServerTest extends AbstractMockServerTest {
                         .getRequestOptions()
                         .getRequestTag()
                         .equals("search_singers_by_last_name_starts_with"))
+            .count());
+    assertEquals(
+        1,
+        mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).stream()
+            .filter(
+                request ->
+                    request
+                        .getSql()
+                        .equals(
+                            "update singer set active=@p1,commit_timestamp_updated=pending_commit_timestamp(),updated_at=@p2 where id=@p3"))
             .count());
   }
 


### PR DESCRIPTION
Adds a sample for automatically generating and assigning commit timestamps when entities are created and updated.