### PR TITLE
fix: use unnest instead of array_contains

### DIFF
--- a/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerSqlAstTranslator.java
+++ b/google-cloud-spanner-hibernate-dialect/src/main/java/com/google/cloud/spanner/hibernate/SpannerSqlAstTranslator.java
@@ -34,6 +34,7 @@ import org.hibernate.sql.ast.tree.from.DerivedTableReference;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
+import org.hibernate.sql.ast.tree.predicate.InArrayPredicate;
 import org.hibernate.sql.ast.tree.predicate.LikePredicate;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.SelectClause;
@@ -77,6 +78,14 @@ public class SpannerSqlAstTranslator<T extends JdbcOperation> extends AbstractSq
             likePredicate.isNegated());
       }
     }
+  }
+
+  @Override
+  public void visitInArrayPredicate(InArrayPredicate inArrayPredicate) {
+    inArrayPredicate.getTestExpression().accept(this);
+    appendSql(" in unnest(");
+    inArrayPredicate.getArrayParameter().accept(this);
+    appendSql(')');
   }
 
   @Override

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SchemaGenerationMockServerTest.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/SchemaGenerationMockServerTest.java
@@ -26,6 +26,7 @@ import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.hibernate.entities.Account;
 import com.google.cloud.spanner.hibernate.entities.Airplane;
 import com.google.cloud.spanner.hibernate.entities.Airport;
+import com.google.cloud.spanner.hibernate.entities.Album;
 import com.google.cloud.spanner.hibernate.entities.AutoIdEntity;
 import com.google.cloud.spanner.hibernate.entities.Child;
 import com.google.cloud.spanner.hibernate.entities.Customer;
@@ -107,7 +108,8 @@ public class SchemaGenerationMockServerTest extends AbstractSchemaGenerationMock
       //noinspection EmptyTryBlock
       try (SessionFactory ignore =
           createTestHibernateConfig(
-                  ImmutableList.of(Singer.class, Invoice.class, Customer.class, Account.class),
+                  ImmutableList.of(
+                      Singer.class, Album.class, Invoice.class, Customer.class, Account.class),
                   ImmutableMap.of("hibernate.hbm2ddl.auto", hbm2Ddl))
               .buildSessionFactory()) {
         // do nothing, just generate the schema.
@@ -121,13 +123,16 @@ public class SchemaGenerationMockServerTest extends AbstractSchemaGenerationMock
               .collect(Collectors.toList());
       assertEquals(1, requests.size());
       UpdateDatabaseDdlRequest request = requests.get(0);
-      assertEquals(8, request.getStatementsCount());
+      assertEquals(10, request.getStatementsCount());
 
       int index = -1;
 
       if (hbm2Ddl.equals("update")) {
         assertEquals(
             "create table Account (id int64 not null,amount numeric,name string(255)) PRIMARY KEY (id)",
+            request.getStatements(++index));
+        assertEquals(
+            "create table Album (id int64 not null,singer int64) PRIMARY KEY (id)",
             request.getStatements(++index));
         assertEquals(
             "create table Customer (customerId int64 not null,name string(255)) PRIMARY KEY (customerId)",
@@ -142,10 +147,13 @@ public class SchemaGenerationMockServerTest extends AbstractSchemaGenerationMock
             "create table invoiceId (next_val int64) PRIMARY KEY ()",
             request.getStatements(++index));
         assertEquals(
-            "create table Singer (id int64 not null) PRIMARY KEY (id)",
+            "create table Singer (id int64 not null,name string(255)) PRIMARY KEY (id)",
             request.getStatements(++index));
         assertEquals(
             "create table singerId (next_val int64) PRIMARY KEY ()",
+            request.getStatements(++index));
+        assertEquals(
+            "alter table Album add constraint fk_album_singer foreign key (singer) references Singer (id)",
             request.getStatements(++index));
         assertEquals(
             "alter table Invoice add constraint fk_invoice_customer foreign key (customer_customerId) references Customer (customerId) on delete cascade",
@@ -153,6 +161,9 @@ public class SchemaGenerationMockServerTest extends AbstractSchemaGenerationMock
       } else {
         assertEquals(
             "create table Account (amount numeric,id int64 not null,name string(255)) PRIMARY KEY (id)",
+            request.getStatements(++index));
+        assertEquals(
+            "create table Album (id int64 not null,singer int64) PRIMARY KEY (id)",
             request.getStatements(++index));
         assertEquals(
             "create table Customer (customerId int64 not null,name string(255)) PRIMARY KEY (customerId)",
@@ -167,10 +178,13 @@ public class SchemaGenerationMockServerTest extends AbstractSchemaGenerationMock
             "create table invoiceId (next_val int64) PRIMARY KEY ()",
             request.getStatements(++index));
         assertEquals(
-            "create table Singer (id int64 not null) PRIMARY KEY (id)",
+            "create table Singer (id int64 not null,name string(255)) PRIMARY KEY (id)",
             request.getStatements(++index));
         assertEquals(
             "create table singerId (next_val int64) PRIMARY KEY ()",
+            request.getStatements(++index));
+        assertEquals(
+            "alter table Album add constraint fk_album_singer foreign key (singer) references Singer (id)",
             request.getStatements(++index));
         assertEquals(
             "alter table Invoice add constraint fk_invoice_customer foreign key (customer_customerId) references Customer (customerId) on delete cascade",
@@ -186,7 +200,8 @@ public class SchemaGenerationMockServerTest extends AbstractSchemaGenerationMock
     //noinspection EmptyTryBlock
     try (SessionFactory ignore =
         createTestHibernateConfig(
-                ImmutableList.of(Singer.class, Invoice.class, Customer.class, Account.class),
+                ImmutableList.of(
+                    Singer.class, Album.class, Invoice.class, Customer.class, Account.class),
                 ImmutableMap.of("hibernate.hbm2ddl.auto", "drop"))
             .buildSessionFactory()) {
       // do nothing, just generate the schema.
@@ -247,7 +262,8 @@ public class SchemaGenerationMockServerTest extends AbstractSchemaGenerationMock
     //noinspection EmptyTryBlock
     try (SessionFactory ignore =
         createTestHibernateConfig(
-                ImmutableList.of(Singer.class, Invoice.class, Customer.class, Account.class),
+                ImmutableList.of(
+                    Singer.class, Album.class, Invoice.class, Customer.class, Account.class),
                 ImmutableMap.of("hibernate.hbm2ddl.auto", "drop"))
             .buildSessionFactory()) {
       // do nothing, just generate the schema.

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/entities/Album.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/entities/Album.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019-2025 Google LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.google.cloud.spanner.hibernate.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Album {
+
+  @Id private long id;
+
+  @ManyToOne
+  @JoinColumn(name = "singer", foreignKey = @ForeignKey(name = "fk_album_singer"))
+  private Singer singer;
+
+  public Album() {}
+
+  public Album(Singer singer, long id) {
+    this.singer = singer;
+    this.id = id;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public Singer getSinger() {
+    return singer;
+  }
+}

--- a/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/entities/Singer.java
+++ b/google-cloud-spanner-hibernate-dialect/src/test/java/com/google/cloud/spanner/hibernate/entities/Singer.java
@@ -24,6 +24,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Check;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
@@ -50,9 +53,28 @@ public class Singer {
   @Column(nullable = false)
   private long id;
 
+  @Column private String name;
+
+  @OneToMany(mappedBy = "singer")
+  @BatchSize(size = 2)
+  private List<Album> albums;
+
   public Singer() {}
+
+  public Singer(long id, String name) {
+    this.id = id;
+    this.name = name;
+  }
 
   public long getId() {
     return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public List<Album> getAlbums() {
+    return albums;
   }
 }

--- a/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/Singer.java
+++ b/google-cloud-spanner-hibernate-samples/spring-data-jpa-full-sample/src/main/java/com/google/cloud/spanner/sample/entities/Singer.java
@@ -26,6 +26,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.List;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.Type;
@@ -61,6 +62,7 @@ public class Singer extends AbstractNonInterleavedEntity {
 
   @OneToMany
   @JoinColumn(name = "singer_id")
+  @BatchSize(size = 10)
   private List<Album> albums;
 
   @OneToMany


### PR DESCRIPTION
Hibernate by default uses the array_contains function when a predicate is created to search for entities where the ID is in an array of elements. array_contains is however not a supported function in Spanner GoogleSQL, and also using `in unnest(@values)` is more efficient on Spanner.

The `visitInArrayPredicate` method is therefore now overridden in the Spanner dialect and uses an `in unnest(@values)` construct instead.

Fixes #1546