### PR TITLE
ci: create profile for releases that do not use nexus-staging plugin

### DIFF
--- a/google-cloud-spanner-hibernate-samples/pom.xml
+++ b/google-cloud-spanner-hibernate-samples/pom.xml
@@ -41,13 +41,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<configuration>
-					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
 				<version>3.4.0</version>

--- a/google-cloud-spanner-hibernate-testing/pom.xml
+++ b/google-cloud-spanner-hibernate-testing/pom.xml
@@ -93,13 +93,6 @@
 					<skip>true</skip>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<configuration>
-					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -332,6 +332,11 @@
     </profile>
     <profile>
       <id>release</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+        </property>
+      </activation>
       <modules>
         <module>google-cloud-spanner-hibernate-dialect</module>
         <module>google-cloud-spanner-hibernate-tools</module>
@@ -384,15 +389,54 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-          </plugin>
-          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <profile>
+      <!-- By default, we release artifacts to Sonatype, which requires
+          nexus-staging-maven-plugin. -->
+      <id>release-sonatype</id>
+      <activation>
+        <property>
+          <!-- Only when we use the release-gcp-artifact-registry profile,
+          which comes with artifact-registry-url property, this profile is
+          turned off. -->
+          <name>!artifact-registry-url</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+          this release-gcp-artifact-registry profile:
+          mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+              -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+          -->
+      <id>release-gcp-artifact-registry</id>
+      <properties>
+        <artifact-registry-url>artifactregistry://please-define-artifact-registry-url-property</artifact-registry-url>
+      </properties>
+      <distributionManagement>
+        <repository>
+          <id>gcp-artifact-registry-repository</id>
+          <url>${artifact-registry-url}</url>
+        </repository>
+        <snapshotRepository>
+          <id>gcp-artifact-registry-repository</id>
+          <url>${artifact-registry-url}</url>
+        </snapshotRepository>
+      </distributionManagement>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
The mvn deploy command worked:

```
suztomo@suztomo2:~/google-cloud-spanner-hibernate$ mvn clean deploy -V     -DaltDeploymentRepository=local::default::file:${local_staging_dir}     -DskipTests=true     -P=-release-sonatype     -P=-release-staging-repository     -P=-clirr-compatibility-check     -P=-checkstyle-tests     -P=-animal-sniffer

suztomo@suztomo2:~/google-cloud-spanner-hibernate$ tree target/staging-deploy/
target/staging-deploy/
└── com
    └── google
        └── cloud
            ├── google-cloud-spanner-hibernate
            │   ├── 3.9.6-SNAPSHOT
            │   │   ├── google-cloud-spanner-hibernate-3.9.6-20250617.205706-1.pom
            │   │   ├── google-cloud-spanner-hibernate-3.9.6-20250617.205706-1.pom.md5
            │   │   ├── google-cloud-spanner-hibernate-3.9.6-20250617.205706-1.pom.sha1
            │   │   ├── maven-metadata.xml
            │   │   ├── maven-metadata.xml.md5
            │   │   └── maven-metadata.xml.sha1
            │   ├── maven-metadata.xml
            │   ├── maven-metadata.xml.md5
            │   └── maven-metadata.xml.sha1
            ├── google-cloud-spanner-hibernate-dialect
            │   ├── 3.9.6-SNAPSHOT
            │   │   ├── google-cloud-spanner-hibernate-dialect-3.9.6-20250617.205706-1.jar
            │   │   ├── google-cloud-spanner-hibernate-dialect-3.9.6-20250617.205706-1.jar.md5
            │   │   ├── google-cloud-spanner-hibernate-dialect-3.9.6-20250617.205706-1.jar.sha1
            │   │   ├── google-cloud-spanner-hibernate-dialect-3.9.6-20250617.205706-1.pom
            │   │   ├── google-cloud-spanner-hibernate-dialect-3.9.6-20250617.205706-1.pom.md5
            │   │   ├── google-cloud-spanner-hibernate-dialect-3.9.6-20250617.205706-1.pom.sha1
            │   │   ├── maven-metadata.xml
            │   │   ├── maven-metadata.xml.md5
            │   │   └── maven-metadata.xml.sha1
            │   ├── maven-metadata.xml
            │   ├── maven-metadata.xml.md5
            │   └── maven-metadata.xml.sha1
            └── google-cloud-spanner-hibernate-tools
                ├── 3.9.6-SNAPSHOT
                │   ├── google-cloud-spanner-hibernate-tools-3.9.6-20250617.205706-1.jar
                │   ├── google-cloud-spanner-hibernate-tools-3.9.6-20250617.205706-1.jar.md5
                │   ├── google-cloud-spanner-hibernate-tools-3.9.6-20250617.205706-1.jar.sha1
                │   ├── google-cloud-spanner-hibernate-tools-3.9.6-20250617.205706-1.pom
                │   ├── google-cloud-spanner-hibernate-tools-3.9.6-20250617.205706-1.pom.md5
                │   ├── google-cloud-spanner-hibernate-tools-3.9.6-20250617.205706-1.pom.sha1
                │   ├── maven-metadata.xml
                │   ├── maven-metadata.xml.md5
                │   └── maven-metadata.xml.sha1
                ├── maven-metadata.xml
                ├── maven-metadata.xml.md5
                └── maven-metadata.xml.sha1

10 directories, 33 files
```
