### PR TITLE
build: explicitly install tools locally before running tests

### DIFF
--- a/.github/workflows/integration-emulator.yml
+++ b/.github/workflows/integration-emulator.yml
@@ -37,6 +37,9 @@ jobs:
 
       - name: Install dependencies
         run: mvn install -DskipTests
+      - name: Install Spanner Hibernate tools
+        working-directory: google-cloud-spanner-hibernate-tools
+        run: mvn install -DskipTests
 
       - name: Run Integration Tests on Emulator
         working-directory: google-cloud-spanner-hibernate-dialect

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,6 +45,9 @@ jobs:
 
       - name: Install dependencies
         run: mvn install -DskipTests
+      - name: Install Spanner Hibernate tools
+        working-directory: google-cloud-spanner-hibernate-tools
+        run: mvn install -DskipTests
 
       - name: Run Integration Tests
         working-directory: google-cloud-spanner-hibernate-dialect


### PR DESCRIPTION
Attempt to fix the build errors in https://github.com/GoogleCloudPlatform/google-cloud-spanner-hibernate/pull/1703