### PR TITLE
ci: fix maven build and test workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,9 +30,9 @@ jobs:
           distribution: temurin
 
       - name: Build with Maven
-        run: mvn install -B -V -DskipTests
+        run: mvn install -B -V -DskipTests -Pdefault
 
       - name: Run Unit Tests
-        run: mvn test
+        run: mvn test -Pdefault
 
 


### PR DESCRIPTION
After PR #1698 , the `mvn install` command stopped building the project's child modules, resulting in an incomplete build
The `release-sonatype` profile is activated whenever `artifact-registry-url` is not set and According to Maven's design, when a profile is activated this way, it automatically disables any profiles that are merely set to be `activeByDefault`









