### PR TITLE
fix(codelab): cast date string literal in HQL query

### DIFF
--- a/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/src/main/java/codelab/App.java
+++ b/google-cloud-spanner-hibernate-samples/spanner-hibernate-codelab/src/main/java/codelab/App.java
@@ -82,7 +82,10 @@ public class App {
 
   private static void readData(Session session) {
     List<Singer> singers =
-        session.createQuery("from Singer where birthDate >= '1990-01-01' order by lastName").list();
+        session
+            .createQuery(
+                "from Singer where birthDate >= cast('1990-01-01' as date) order by lastName")
+            .list();
     System.out.println("Singers who were born in 1990 or later:");
     for (Singer singer : singers) {
       System.out.println(


### PR DESCRIPTION
Cast the date string literal into a date in the HQL query in `spanner-hibernate-codelab` to resolve `org.hibernate.query.SemanticException: Cannot compare left expression of type 'java.sql.Date' with right expression of type 'java.lang.String'` under Hibernate 6/7.

Fixes #1107

b/344084173